### PR TITLE
refactor tidy up clap commands

### DIFF
--- a/sapphire-cli/src/cli/uninstall.rs
+++ b/sapphire-cli/src/cli/uninstall.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
 
+use clap::Args;
 use colored::Colorize;
-use log;
 use sapphire_core::build;
 use sapphire_core::build::cask::{CaskInstallManifest, InstalledArtifact};
 use sapphire_core::fetch::api;
@@ -12,314 +12,331 @@ use sapphire_core::model::cask::Cask;
 use sapphire_core::utils::cache::Cache;
 use sapphire_core::utils::config::Config;
 use sapphire_core::utils::error::{Result, SapphireError};
-use serde_json;
-use walkdir;
+use {log, serde_json, walkdir};
 
 use crate::cli::info;
 use crate::ui;
 
-pub async fn run_uninstall(names: &[String], config: &Config, cache: Arc<Cache>) -> Result<()> {
-    let mut errors: Vec<(String, SapphireError)> = Vec::new(); // Store errors per package name
+#[derive(Args, Debug)]
+pub struct Uninstall {
+    /// The names of the formulas or casks to uninstall
+    #[arg(required = true)] // Ensure at least one name is given
+    pub names: Vec<String>,
+}
 
-    for name in names {
-        let pb = ui::create_spinner(&format!("Uninstalling {}", name));
+impl Uninstall {
+    /// Run the uninstall command
+    pub async fn run(&self, config: &Config, cache: Arc<Cache>) -> Result<()> {
+        let names = &self.names;
+        let mut errors: Vec<(String, SapphireError)> = Vec::new(); // Store errors per package name
 
-        let formula_result = info::get_formula_info(name, config, &cache).await;
-        let is_formula = formula_result.is_ok();
+        for name in names {
+            let pb = ui::create_spinner(&format!("Uninstalling {}", name));
 
-        if is_formula {
-            // --- Formula Uninstall Logic (largely unchanged, uses existing manifest) ---
-            let formula = formula_result.unwrap(); // Safe unwrap due to is_ok() check
-            log::debug!("Attempting to uninstall formula: {}", name);
-            let cellar_path = config.formula_keg_path(formula.name(), &formula.version_str_full());
+            let formula_result = info::get_formula_info(name, config, Arc::clone(&cache)).await;
+            let is_formula = formula_result.is_ok();
 
-            if !cellar_path.exists() {
-                log::warn!(
-                    "Formula '{}' info found but keg missing: {}. Attempting cleanup.",
-                    name,
-                    cellar_path.display()
-                );
+            if is_formula {
+                // --- Formula Uninstall Logic (largely unchanged, uses existing manifest) ---
+                let formula = formula_result.unwrap(); // Safe unwrap due to is_ok() check
+                log::debug!("Attempting to uninstall formula: {}", name);
+                let cellar_path =
+                    config.formula_keg_path(formula.name(), &formula.version_str_full());
+
+                if !cellar_path.exists() {
+                    log::warn!(
+                        "Formula '{}' info found but keg missing: {}. Attempting cleanup.",
+                        name,
+                        cellar_path.display()
+                    );
+                    match build::formula::link::unlink_formula_artifacts(&formula, config) {
+                        Ok(_) => pb.finish_with_message(format!(
+                            "Unlinked remaining artifacts for {} (keg missing)",
+                            name
+                        )),
+                        Err(e) => {
+                            log::error!(
+                                "Failed to unlink artifacts for missing keg {}: {}",
+                                formula.name(),
+                                e
+                            );
+                            errors.push((
+                                name.to_string(),
+                                SapphireError::NotFound(format!(
+                                    "Formula '{}' is not installed (no keg at {})",
+                                    name,
+                                    cellar_path.display()
+                                )),
+                            ));
+                            pb.finish_and_clear();
+                        }
+                    }
+                    continue;
+                }
+
+                let (file_count, size_bytes) = count_files_and_size(&cellar_path).unwrap_or((0, 0));
+                let mut unlink_error: Option<SapphireError> = None;
                 match build::formula::link::unlink_formula_artifacts(&formula, config) {
-                    Ok(_) => pb.finish_with_message(format!(
-                        "Unlinked remaining artifacts for {} (keg missing)",
-                        name
-                    )),
+                    Ok(_) => log::debug!("Successfully unlinked artifacts for {}", formula.name()),
                     Err(e) => {
                         log::error!(
-                            "Failed to unlink artifacts for missing keg {}: {}",
+                            "Failed to unlink artifacts for {}: {}. Proceeding with keg removal.",
                             formula.name(),
                             e
+                        );
+                        unlink_error = Some(e);
+                    }
+                }
+
+                log::debug!("Removing formula keg directory: {}", cellar_path.display());
+                if let Err(e) = fs::remove_dir_all(&cellar_path) {
+                    let removal_error = SapphireError::Io(std::io::Error::new(
+                        e.kind(),
+                        format!("Failed remove keg {}: {}", cellar_path.display(), e),
+                    ));
+                    log::error!("{}", removal_error);
+                    errors.push((name.to_string(), removal_error));
+                    pb.finish_and_clear();
+                    continue;
+                }
+
+                if let Some(e) = unlink_error {
+                    errors.push((name.to_string(), e)); // Record unlink error after successful removal
+                    pb.finish_and_clear();
+                } else {
+                    pb.finish_with_message(format!(
+                        "Uninstalled {} ({} files, {})",
+                        cellar_path.display(),
+                        file_count,
+                        format_size(size_bytes)
+                    ));
+                }
+                continue; // Successfully uninstalled formula
+            }
+
+            // --- Cask Uninstall Logic (New Manifest-Based) ---
+            match api::fetch_cask(name).await {
+                // Fetch JSON definition
+                Ok(cask_json) => {
+                    let cask: Cask = match serde_json::from_value(cask_json) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            log::error!("Failed to parse cask JSON for {}: {}", name, e);
+                            errors.push((name.to_string(), SapphireError::Json(e)));
+                            pb.finish_and_clear();
+                            continue;
+                        }
+                    };
+                    log::debug!("Attempting to uninstall cask: {}", name);
+
+                    let installed_version = match cask.installed_version(config) {
+                        Some(v) => v,
+                        None => {
+                            log::info!("Cask '{}' is not installed.", name);
+                            // Avoid double "not found" if formula also wasn't found.
+                            if errors
+                                .iter()
+                                .all(|(n, e)| n != name || !matches!(e, SapphireError::NotFound(_)))
+                            {
+                                // Only add error if it wasn't already marked as not found
+                                errors.push((
+                                    name.to_string(),
+                                    SapphireError::NotFound(format!(
+                                        "Cask '{}' is not installed",
+                                        name
+                                    )),
+                                ));
+                            }
+                            pb.finish_and_clear();
+                            continue;
+                        }
+                    };
+                    let cask_version_path =
+                        config.cask_version_path(&cask.token, &installed_version);
+
+                    if !cask_version_path.exists() {
+                        log::error!(
+                            "Cask '{}' version '{}' inconsistent: Dir missing: {}",
+                            name,
+                            installed_version,
+                            cask_version_path.display()
                         );
                         errors.push((
                             name.to_string(),
                             SapphireError::NotFound(format!(
-                                "Formula '{}' is not installed (no keg at {})",
-                                name,
-                                cellar_path.display()
+                                "Cask '{}' version '{}' installation is inconsistent (missing dir)",
+                                name, installed_version
                             )),
                         ));
                         pb.finish_and_clear();
-                    }
-                }
-                continue;
-            }
-
-            let (file_count, size_bytes) = count_files_and_size(&cellar_path).unwrap_or((0, 0));
-            let mut unlink_error: Option<SapphireError> = None;
-            match build::formula::link::unlink_formula_artifacts(&formula, config) {
-                Ok(_) => log::debug!("Successfully unlinked artifacts for {}", formula.name()),
-                Err(e) => {
-                    log::error!(
-                        "Failed to unlink artifacts for {}: {}. Proceeding with keg removal.",
-                        formula.name(),
-                        e
-                    );
-                    unlink_error = Some(e);
-                }
-            }
-
-            log::debug!("Removing formula keg directory: {}", cellar_path.display());
-            if let Err(e) = fs::remove_dir_all(&cellar_path) {
-                let removal_error = SapphireError::Io(std::io::Error::new(
-                    e.kind(),
-                    format!("Failed remove keg {}: {}", cellar_path.display(), e),
-                ));
-                log::error!("{}", removal_error);
-                errors.push((name.to_string(), removal_error));
-                pb.finish_and_clear();
-                continue;
-            }
-
-            if let Some(e) = unlink_error {
-                errors.push((name.to_string(), e)); // Record unlink error after successful removal
-                pb.finish_and_clear();
-            } else {
-                pb.finish_with_message(format!(
-                    "Uninstalled {} ({} files, {})",
-                    cellar_path.display(),
-                    file_count,
-                    format_size(size_bytes)
-                ));
-            }
-            continue; // Successfully uninstalled formula
-        }
-
-        // --- Cask Uninstall Logic (New Manifest-Based) ---
-        match api::fetch_cask(name).await {
-            // Fetch JSON definition
-            Ok(cask_json) => {
-                let cask: Cask = match serde_json::from_value(cask_json) {
-                    Ok(c) => c,
-                    Err(e) => {
-                        log::error!("Failed to parse cask JSON for {}: {}", name, e);
-                        errors.push((name.to_string(), SapphireError::Json(e)));
-                        pb.finish_and_clear();
                         continue;
                     }
-                };
-                log::debug!("Attempting to uninstall cask: {}", name);
 
-                let installed_version = match cask.installed_version(config) {
-                    Some(v) => v,
-                    None => {
-                        log::info!("Cask '{}' is not installed.", name);
-                        // Avoid double "not found" if formula also wasn't found.
-                        if errors
-                            .iter()
-                            .all(|(n, e)| n != name || !matches!(e, SapphireError::NotFound(_)))
-                        {
-                            // Only add error if it wasn't already marked as not found
-                            errors.push((
-                                name.to_string(),
-                                SapphireError::NotFound(format!(
-                                    "Cask '{}' is not installed",
-                                    name
-                                )),
-                            ));
-                        }
-                        pb.finish_and_clear();
-                        continue;
-                    }
-                };
-                let cask_version_path = config.cask_version_path(&cask.token, &installed_version);
+                    let (file_count, size_bytes) =
+                        count_files_and_size(&cask_version_path).unwrap_or((0, 0));
 
-                if !cask_version_path.exists() {
-                    log::error!(
-                        "Cask '{}' version '{}' inconsistent: Dir missing: {}",
-                        name,
-                        installed_version,
-                        cask_version_path.display()
-                    );
-                    errors.push((
-                        name.to_string(),
-                        SapphireError::NotFound(format!(
-                            "Cask '{}' version '{}' installation is inconsistent (missing dir)",
-                            name, installed_version
-                        )),
-                    ));
-                    pb.finish_and_clear();
-                    continue;
-                }
+                    // --- Process CASK_INSTALL_MANIFEST.json ---
+                    let manifest_path = cask_version_path.join("CASK_INSTALL_MANIFEST.json");
+                    let mut artifact_removal_errors = 0;
 
-                let (file_count, size_bytes) =
-                    count_files_and_size(&cask_version_path).unwrap_or((0, 0));
-
-                // --- Process CASK_INSTALL_MANIFEST.json ---
-                let manifest_path = cask_version_path.join("CASK_INSTALL_MANIFEST.json");
-                let mut artifact_removal_errors = 0;
-
-                if manifest_path.is_file() {
-                    log::debug!("Processing manifest: {}", manifest_path.display());
-                    match fs::read_to_string(&manifest_path) {
-                        Ok(manifest_str) => {
-                            match serde_json::from_str::<CaskInstallManifest>(&manifest_str) {
-                                Ok(manifest) => {
-                                    for artifact in manifest.artifacts.iter().rev() {
-                                        // Iterate backward for safety
-                                        if !process_artifact_uninstall(artifact) {
-                                            artifact_removal_errors += 1;
+                    if manifest_path.is_file() {
+                        log::debug!("Processing manifest: {}", manifest_path.display());
+                        match fs::read_to_string(&manifest_path) {
+                            Ok(manifest_str) => {
+                                match serde_json::from_str::<CaskInstallManifest>(&manifest_str) {
+                                    Ok(manifest) => {
+                                        for artifact in manifest.artifacts.iter().rev() {
+                                            // Iterate backward for safety
+                                            if !process_artifact_uninstall(artifact) {
+                                                artifact_removal_errors += 1;
+                                            }
                                         }
                                     }
-                                }
-                                Err(e) => {
-                                    log::warn!("Failed to parse cask manifest {}: {}. Falling back to directory removal only.", manifest_path.display(), e);
-                                    errors.push((
-                                        name.to_string(),
-                                        SapphireError::Generic(format!(
-                                            "Failed parse manifest for cask '{}'",
-                                            name
-                                        )),
-                                    ));
-                                    artifact_removal_errors += 1; // Count as error if manifest is
-                                                                  // unparseable
+                                    Err(e) => {
+                                        log::warn!("Failed to parse cask manifest {}: {}. Falling back to directory removal only.", manifest_path.display(), e);
+                                        errors.push((
+                                            name.to_string(),
+                                            SapphireError::Generic(format!(
+                                                "Failed parse manifest for cask '{}'",
+                                                name
+                                            )),
+                                        ));
+                                        artifact_removal_errors += 1; // Count as error if manifest
+                                                                      // is
+                                                                      // unparseable
+                                    }
                                 }
                             }
+                            Err(e) => {
+                                log::warn!("Failed to read cask manifest {}: {}. Falling back to directory removal only.", manifest_path.display(), e);
+                                errors.push((
+                                    name.to_string(),
+                                    SapphireError::Generic(format!(
+                                        "Failed read manifest for cask '{}'",
+                                        name
+                                    )),
+                                ));
+                                artifact_removal_errors += 1; // Count as error if manifest cannot
+                                                              // be
+                                                              // read
+                            }
                         }
-                        Err(e) => {
-                            log::warn!("Failed to read cask manifest {}: {}. Falling back to directory removal only.", manifest_path.display(), e);
+                    } else {
+                        log::warn!("No CASK_INSTALL_MANIFEST.json found for cask {}. Uninstalling Caskroom directory only.", name);
+                        // This is not necessarily an error, just a limitation. Don't increment
+                        // artifact_removal_errors here.
+                    }
+
+                    // --- Remove Caskroom Version Directory ---
+                    log::debug!(
+                        "Removing cask version directory: {}",
+                        cask_version_path.display()
+                    );
+                    if let Err(e) = fs::remove_dir_all(&cask_version_path) {
+                        log::error!(
+                            "Failed to remove cask version directory {}: {}",
+                            cask_version_path.display(),
+                            e
+                        );
+                        errors.push((
+                            name.to_string(),
+                            SapphireError::Io(std::io::Error::new(
+                                e.kind(),
+                                format!("Failed to remove cask version dir for '{}'", name),
+                            )),
+                        ));
+                        // If dir removal fails, stop processing this cask.
+                        pb.finish_and_clear();
+                        continue;
+                    }
+
+                    // --- Cleanup Parent Directory (if empty) ---
+                    let parent_cask_dir = config.cask_dir(&cask.token);
+                    cleanup_parent_cask_dir(&parent_cask_dir);
+
+                    // --- Final Message ---
+                    if artifact_removal_errors == 0 && errors.iter().all(|(n, _)| n != name) {
+                        // Check errors specifically for this cask
+                        pb.finish_with_message(format!(
+                            "Uninstalled {} (~{} files, ~{})",
+                            cask_version_path.display(),
+                            file_count,
+                            format_size(size_bytes)
+                        ));
+                    } else {
+                        log::warn!(
+                            "Uninstalled {} but encountered {} artifact removal errors.",
+                            cask_version_path.display(),
+                            artifact_removal_errors
+                        );
+                        // Add generic error if needed
+                        if errors.iter().all(|(n, _)| n != name) {
                             errors.push((
                                 name.to_string(),
                                 SapphireError::Generic(format!(
-                                    "Failed read manifest for cask '{}'",
-                                    name
+                                    "Encountered {} errors removing artifacts for cask '{}'",
+                                    artifact_removal_errors, name
                                 )),
                             ));
-                            artifact_removal_errors += 1; // Count as error if manifest cannot be
-                                                          // read
                         }
+                        pb.finish_and_clear();
                     }
-                } else {
-                    log::warn!("No CASK_INSTALL_MANIFEST.json found for cask {}. Uninstalling Caskroom directory only.", name);
-                    // This is not necessarily an error, just a limitation. Don't increment
-                    // artifact_removal_errors here.
+                    continue; // Successfully uninstalled cask (or attempted to)
                 }
-
-                // --- Remove Caskroom Version Directory ---
-                log::debug!(
-                    "Removing cask version directory: {}",
-                    cask_version_path.display()
-                );
-                if let Err(e) = fs::remove_dir_all(&cask_version_path) {
-                    log::error!(
-                        "Failed to remove cask version directory {}: {}",
-                        cask_version_path.display(),
-                        e
-                    );
-                    errors.push((
-                        name.to_string(),
-                        SapphireError::Io(std::io::Error::new(
-                            e.kind(),
-                            format!("Failed to remove cask version dir for '{}'", name),
-                        )),
-                    ));
-                    // If dir removal fails, stop processing this cask.
-                    pb.finish_and_clear();
-                    continue;
-                }
-
-                // --- Cleanup Parent Directory (if empty) ---
-                let parent_cask_dir = config.cask_dir(&cask.token);
-                cleanup_parent_cask_dir(&parent_cask_dir);
-
-                // --- Final Message ---
-                if artifact_removal_errors == 0 && errors.iter().all(|(n, _)| n != name) {
-                    // Check errors specifically for this cask
-                    pb.finish_with_message(format!(
-                        "Uninstalled {} (~{} files, ~{})",
-                        cask_version_path.display(),
-                        file_count,
-                        format_size(size_bytes)
-                    ));
-                } else {
-                    log::warn!(
-                        "Uninstalled {} but encountered {} artifact removal errors.",
-                        cask_version_path.display(),
-                        artifact_removal_errors
-                    );
-                    // Add generic error if needed
-                    if errors.iter().all(|(n, _)| n != name) {
+                Err(SapphireError::NotFound(_)) => {
+                    log::error!("Formula or Cask '{}' not found.", name);
+                    // Avoid double "not found" errors
+                    if errors
+                        .iter()
+                        .all(|(n, e)| n != name || !matches!(e, SapphireError::NotFound(_)))
+                    {
                         errors.push((
                             name.to_string(),
-                            SapphireError::Generic(format!(
-                                "Encountered {} errors removing artifacts for cask '{}'",
-                                artifact_removal_errors, name
+                            SapphireError::NotFound(format!(
+                                "Formula or Cask '{}' not found",
+                                name
                             )),
                         ));
                     }
                     pb.finish_and_clear();
+                    continue;
                 }
-                continue; // Successfully uninstalled cask (or attempted to)
-            }
-            Err(SapphireError::NotFound(_)) => {
-                log::error!("Formula or Cask '{}' not found.", name);
-                // Avoid double "not found" errors
-                if errors
-                    .iter()
-                    .all(|(n, e)| n != name || !matches!(e, SapphireError::NotFound(_)))
-                {
-                    errors.push((
-                        name.to_string(),
-                        SapphireError::NotFound(format!("Formula or Cask '{}' not found", name)),
-                    ));
+                Err(e) => {
+                    log::error!("Error getting cask info for '{}': {}", name, e);
+                    errors.push((name.to_string(), e));
+                    pb.finish_and_clear();
+                    continue;
                 }
-                pb.finish_and_clear();
-                continue;
             }
-            Err(e) => {
-                log::error!("Error getting cask info for '{}': {}", name, e);
-                errors.push((name.to_string(), e));
-                pb.finish_and_clear();
-                continue;
-            }
-        }
-    } // End loop over names
+        } // End loop over names
 
-    if !errors.is_empty() {
-        eprintln!("\n{}:", "Finished uninstalling with errors".yellow());
-        // Group errors by package name
-        let mut errors_by_pkg: std::collections::HashMap<String, Vec<String>> =
-            std::collections::HashMap::new();
-        for (pkg_name, error) in errors {
-            errors_by_pkg
-                .entry(pkg_name)
-                .or_default()
-                .push(error.to_string());
-        }
-        for (pkg_name, error_list) in errors_by_pkg {
-            eprintln!("  Package '{}':", pkg_name.cyan());
-            // Deduplicate errors for the same package
-            let unique_errors: std::collections::HashSet<_> = error_list.into_iter().collect();
-            for error_str in unique_errors {
-                eprintln!("    - {}", error_str.red());
+        if !errors.is_empty() {
+            eprintln!("\n{}:", "Finished uninstalling with errors".yellow());
+            // Group errors by package name
+            let mut errors_by_pkg: std::collections::HashMap<String, Vec<String>> =
+                std::collections::HashMap::new();
+            for (pkg_name, error) in errors {
+                errors_by_pkg
+                    .entry(pkg_name)
+                    .or_default()
+                    .push(error.to_string());
             }
+            for (pkg_name, error_list) in errors_by_pkg {
+                eprintln!("  Package '{}':", pkg_name.cyan());
+                // Deduplicate errors for the same package
+                let unique_errors: std::collections::HashSet<_> = error_list.into_iter().collect();
+                for error_str in unique_errors {
+                    eprintln!("    - {}", error_str.red());
+                }
+            }
+
+            return Err(SapphireError::Generic(format!(
+                "Uninstall failed for one or more packages."
+            )));
         }
 
-        return Err(SapphireError::Generic(format!(
-            "Uninstall failed for one or more packages."
-        )));
+        Ok(())
     }
-
-    Ok(())
 }
 
 /// Helper function to process the uninstallation of a single artifact from the manifest.

--- a/sapphire-cli/src/cli/update.rs
+++ b/sapphire-cli/src/cli/update.rs
@@ -1,5 +1,4 @@
-// src/cmd/update.rs
-// Contains the logic for the `update` command.
+//! Contains the logic for the `update` command.
 use std::fs;
 use std::sync::Arc;
 
@@ -8,66 +7,70 @@ use sapphire_core::utils::cache::Cache;
 use sapphire_core::utils::config::Config;
 use sapphire_core::utils::error::Result;
 
-use crate::ui; // <-- ADDED: Import ui module
+use crate::ui;
 
-// Updated function signature (accepts Config and Cache)
-pub async fn run_update(config: &Config, cache: &Arc<Cache>) -> Result<()> {
-    log::debug!("Running manual update..."); // Log clearly it's the manual one
+#[derive(clap::Args, Debug)]
+pub struct Update;
 
-    // Use the ui utility function to create the spinner
-    let pb = ui::create_spinner("Updating package lists"); // <-- CHANGED
+impl Update {
+    pub async fn run(&self, config: &Config, cache: Arc<Cache>) -> Result<()> {
+        log::debug!("Running manual update..."); // Log clearly it's the manual one
 
-    log::debug!("Using cache directory: {:?}", config.cache_dir);
+        // Use the ui utility function to create the spinner
+        let pb = ui::create_spinner("Updating package lists"); // <-- CHANGED
 
-    // Fetch and store raw formula data
-    match api::fetch_all_formulas().await {
-        Ok(raw_data) => {
-            cache.store_raw("formula.json", &raw_data)?;
-            log::debug!("✓ Successfully cached formulas data");
-            pb.set_message("Cached formulas data");
+        log::debug!("Using cache directory: {:?}", config.cache_dir);
+
+        // Fetch and store raw formula data
+        match api::fetch_all_formulas().await {
+            Ok(raw_data) => {
+                cache.store_raw("formula.json", &raw_data)?;
+                log::debug!("✓ Successfully cached formulas data");
+                pb.set_message("Cached formulas data");
+            }
+            Err(e) => {
+                let err_msg = format!("Failed to fetch/store formulas from API: {}", e);
+                log::error!("{}", err_msg);
+                pb.finish_and_clear(); // Clear spinner on error
+                return Err(e.into());
+            }
         }
-        Err(e) => {
-            let err_msg = format!("Failed to fetch/store formulas from API: {}", e);
-            log::error!("{}", err_msg);
-            pb.finish_and_clear(); // Clear spinner on error
-            return Err(e.into());
+
+        // Fetch and store raw cask data
+        match api::fetch_all_casks().await {
+            Ok(raw_data) => {
+                cache.store_raw("cask.json", &raw_data)?;
+                log::debug!("✓ Successfully cached casks data");
+                pb.set_message("Cached casks data");
+            }
+            Err(e) => {
+                let err_msg = format!("Failed to fetch/store casks from API: {}", e);
+                log::error!("{}", err_msg);
+                pb.finish_and_clear(); // Clear spinner on error
+                return Err(e.into());
+            }
         }
+
+        // Update timestamp file
+        let timestamp_file = config.cache_dir.join(".sapphire_last_update_check");
+        log::debug!(
+            "Manual update successful. Updating timestamp file: {}",
+            timestamp_file.display()
+        );
+        match fs::File::create(&timestamp_file) {
+            Ok(_) => {
+                log::debug!("Updated timestamp file successfully.");
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to create or update timestamp file '{}': {}",
+                    timestamp_file.display(),
+                    e
+                );
+            }
+        }
+
+        pb.finish_with_message("Update completed successfully!");
+        Ok(())
     }
-
-    // Fetch and store raw cask data
-    match api::fetch_all_casks().await {
-        Ok(raw_data) => {
-            cache.store_raw("cask.json", &raw_data)?;
-            log::debug!("✓ Successfully cached casks data");
-            pb.set_message("Cached casks data");
-        }
-        Err(e) => {
-            let err_msg = format!("Failed to fetch/store casks from API: {}", e);
-            log::error!("{}", err_msg);
-            pb.finish_and_clear(); // Clear spinner on error
-            return Err(e.into());
-        }
-    }
-
-    // Update timestamp file
-    let timestamp_file = config.cache_dir.join(".sapphire_last_update_check");
-    log::debug!(
-        "Manual update successful. Updating timestamp file: {}",
-        timestamp_file.display()
-    );
-    match fs::File::create(&timestamp_file) {
-        Ok(_) => {
-            log::debug!("Updated timestamp file successfully.");
-        }
-        Err(e) => {
-            log::warn!(
-                "Failed to create or update timestamp file '{}': {}",
-                timestamp_file.display(),
-                e
-            );
-        }
-    }
-
-    pb.finish_with_message("Update completed successfully!");
-    Ok(())
 }

--- a/sapphire-cli/src/main.rs
+++ b/sapphire-cli/src/main.rs
@@ -12,10 +12,63 @@ use sapphire_core::utils::error::Result as SapphireResult; // Alias to avoid cla
 mod cli;
 mod ui;
 
-use cli::{CliArgs, Commands};
+use cli::{CliArgs, Command};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Parse command line arguments using the Cli struct
+    let cli_args = CliArgs::parse();
+
+    // Initialize logger based on verbosity (default to info)
+    let log_level = match cli_args.verbose {
+        0 => "info",
+        1 => "debug",
+        _ => "trace",
+    };
+    env_logger::Builder::from_env(env_logger::Env::default().filter_or("SAPPHIRE_LOG", log_level))
+        .format_timestamp(None)
+        .init();
+
+    // Initialize config *before* auto-update check
+    let config = Config::load().unwrap_or_else(|e| {
+        eprintln!("{}: Could not load config: {}", "Error".red().bold(), e);
+        process::exit(1);
+    });
+
+    // Create Cache once and wrap in Arc
+    let cache = Arc::new(
+        Cache::new(&config.cache_dir)
+            .map_err(|e| anyhow::anyhow!("Could not initialize cache: {}", e))?,
+    );
+
+    let needs_update_check = matches!(
+        cli_args.command,
+        // Add Commands::Upgrade here when implemented. Note: Uninstall is intentionally excluded
+        Command::Install(_) | Command::Search { .. } | Command::Info { .. }
+    );
+
+    if needs_update_check {
+        if let Err(e) = check_and_run_auto_update(&config, Arc::clone(&cache)).await {
+            // Log the error from the check itself, but don't exit
+            log::error!("Error during auto-update check: {}", e);
+        }
+    } else {
+        log::debug!(
+            "Skipping auto-update check for command: {:?}",
+            cli_args.command
+        );
+    }
+
+    if let Err(e) = cli_args.command.run(&config, cache).await {
+        eprintln!("{}: {:#}", "Error".red().bold(), e);
+        process::exit(1);
+    }
+
+    Ok(())
+}
 
 /// Checks if auto-update is needed and runs it.
-async fn check_and_run_auto_update(config: &Config, cache: &Arc<Cache>) -> SapphireResult<()> {
+async fn check_and_run_auto_update(config: &Config, cache: Arc<Cache>) -> SapphireResult<()> {
     // 1. Check if auto-update is disabled
     if env::var("SAPPHIRE_NO_AUTO_UPDATE").map_or(false, |v| v == "1") {
         log::debug!("Auto-update disabled via SAPPHIRE_NO_AUTO_UPDATE=1.");
@@ -72,7 +125,7 @@ async fn check_and_run_auto_update(config: &Config, cache: &Arc<Cache>) -> Sapph
     if needs_update {
         println!("Running auto-update...");
         // Use the existing update command logic
-        match cli::update::run_update(config, cache).await {
+        match cli::update::Update.run(config, cache).await {
             // Pass Arc::clone if needed, depends on run_update signature
             Ok(_) => {
                 println!("Auto-update successful.");
@@ -98,91 +151,6 @@ async fn check_and_run_auto_update(config: &Config, cache: &Arc<Cache>) -> Sapph
         }
     } else {
         log::debug!("Skipping auto-update.");
-    }
-
-    Ok(())
-}
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Parse command line arguments using the Cli struct
-    let cli_args = CliArgs::parse();
-
-    // Initialize logger based on verbosity (default to info)
-    let log_level = match cli_args.verbose {
-        0 => "info",
-        1 => "debug",
-        _ => "trace",
-    };
-    env_logger::Builder::from_env(env_logger::Env::default().filter_or("SAPPHIRE_LOG", log_level))
-        .format_timestamp(None)
-        .init();
-
-    // Initialize config *before* auto-update check
-    let config = Config::load().unwrap_or_else(|e| {
-        eprintln!("{}: Could not load config: {}", "Error".red().bold(), e);
-        process::exit(1);
-    });
-
-    // Create Cache once and wrap in Arc
-    let cache = Arc::new(
-        Cache::new(&config.cache_dir)
-            .map_err(|e| anyhow::anyhow!("Could not initialize cache: {}", e))?,
-    );
-
-    let needs_update_check = matches!(
-        cli_args.command,
-        Commands::Install(_) | Commands::Search { .. } | Commands::Info { .. } /* Add Commands::Upgrade here when implemented
-                                                                                * Note: Uninstall { .. } is intentionally excluded */
-    );
-
-    if needs_update_check {
-        if let Err(e) = check_and_run_auto_update(&config, &cache).await {
-            // Log the error from the check itself, but don't exit
-            log::error!("Error during auto-update check: {}", e);
-        }
-    } else {
-        log::debug!(
-            "Skipping auto-update check for command: {:?}",
-            cli_args.command
-        );
-    }
-
-    // Run the requested command
-    let command_result = match cli_args.command {
-        Commands::Install(args) => cli::install::execute(&args, &config, Arc::clone(&cache)).await,
-        // Modified call to pass the vector `names`
-        Commands::Uninstall { names } => {
-            cli::uninstall::run_uninstall(&names, &config, Arc::clone(&cache)).await
-        }
-        Commands::Update => cli::update::run_update(&config, &Arc::clone(&cache)).await, // User-invoked update still runs normally
-        Commands::Search {
-            query,
-            formula,
-            cask,
-        } => {
-            // Determine search type based on flags
-            let search_type = if formula {
-                cli::search::SearchType::Formula
-            } else if cask {
-                cli::search::SearchType::Cask
-            } else {
-                cli::search::SearchType::All
-            };
-            cli::search::run_search(&query, search_type, &config, &Arc::clone(&cache)).await
-        }
-        Commands::Info { name, cask } => {
-            cli::info::run_info(&name, cask, &config, &Arc::clone(&cache)).await
-        } //Commands::Upgrade => {
-          //    cmd::upgrade::run_upgrade().await
-          //}
-    };
-
-    // Handle potential errors from command execution
-    if let Err(e) = command_result {
-        // Use eprintln for errors that should be visible to the user
-        eprintln!("{}: {:#}", "Error".red().bold(), e);
-        process::exit(1);
     }
 
     Ok(())

--- a/sapphire-core/src/build/cask/mod.rs
+++ b/sapphire-core/src/build/cask/mod.rs
@@ -506,8 +506,8 @@ pub fn install_cask(cask: &Cask, download_path: &Path, config: &Config) -> Resul
                             config,
                         ),
                         // Stanzas processed at install time but don't move files from stage
-                        "zap" => artifacts::zap::install_zap(cask, config), /* Zap doesn't use
-                                                                              * stage_path */
+                        "zap" => artifacts::zap::install_zap(cask, config), /* Zap doesn't use */
+                        // stage_path
                         "preflight" => {
                             artifacts::preflight::run_preflight(cask, stage_path, config)
                         } // Uses stage_path


### PR DESCRIPTION
This:
- pulls out each command into its own struct
- Renames Commands to Command
- Moves the match statement into a new command.run()
- implements a run method on each command
- changes the &Arc params to just Arc (no need to have a ref to an arc as they're generally just cloned and counted)
