### PR TITLE
refactor(build/source): implement CWD build detection with nesting support

### DIFF
--- a/sapphire-core/src/build/extract.rs
+++ b/sapphire-core/src/build/extract.rs
@@ -14,6 +14,220 @@ use xz2::read::XzDecoder;
 use zip::read::ZipArchive;
 
 use crate::utils::error::{Result, SapphireError};
+use std::collections::HashSet;
+use tar::Archive;
+
+/// Infers the single top-level directory within an archive, if one exists.
+/// Returns Ok(Some(PathBuf)) if a single root dir is found (e.g., "foo-1.2/").
+/// Returns Ok(None) if the archive is flat or has multiple top-level items.
+/// Returns Err on I/O or parsing errors.
+pub(crate) fn infer_archive_root_dir(
+    archive_path: &Path,
+    archive_type: &str,
+) -> Result<Option<PathBuf>> {
+    tracing::debug!(
+        "Inferring root directory for archive: {}",
+        archive_path.display()
+    );
+    let file = File::open(archive_path).map_err(|e| {
+        SapphireError::Io(std::io::Error::new(
+            e.kind(),
+            format!(
+                "Failed to open archive {}: {}",
+                archive_path.display(),
+                e
+            ),
+        ))
+    })?;
+
+    match archive_type {
+        "zip" => infer_zip_root(file, archive_path),
+        "gz" | "tgz" => {
+            let decompressed = GzDecoder::new(file);
+            infer_tar_root(decompressed, archive_path)
+        }
+        "bz2" | "tbz" | "tbz2" => {
+            let decompressed = BzDecoder::new(file);
+            infer_tar_root(decompressed, archive_path)
+        }
+        "xz" | "txz" => {
+            let decompressed = XzDecoder::new(file);
+            infer_tar_root(decompressed, archive_path)
+        }
+        "tar" => infer_tar_root(file, archive_path),
+        _ => Err(SapphireError::Generic(format!(
+            "Cannot infer root dir for unsupported archive type '{}' in {}",
+            archive_type,
+            archive_path.display()
+        ))),
+    }
+}
+
+// Helper for TAR formats
+fn infer_tar_root<R: Read>(reader: R, archive_path_for_log: &Path) -> Result<Option<PathBuf>> {
+    let mut archive = Archive::new(reader);
+    let mut unique_roots = HashSet::new();
+    let mut non_empty_entry_found = false;
+    let mut first_component_name: Option<PathBuf> = None;
+
+    for entry_result in archive.entries()? {
+        let entry = entry_result.map_err(|e| {
+            SapphireError::Generic(format!(
+                "Error reading TAR entry from {}: {}",
+                archive_path_for_log.display(),
+                e
+            ))
+        })?;
+        let path = entry
+            .path()
+            .map_err(|e| {
+                SapphireError::Generic(format!(
+                    "Invalid path in TAR entry from {}: {}",
+                    archive_path_for_log.display(),
+                    e
+                ))
+            })?
+            .into_owned();
+
+        // Ignore metadata-only entries like pax headers if they have no components
+        if path.components().next().is_none() {
+            continue;
+        }
+
+        if let Some(first_comp) = path.components().next() {
+            if let Component::Normal(name) = first_comp {
+                non_empty_entry_found = true;
+                let current_root = PathBuf::from(name);
+                if first_component_name.is_none() {
+                    first_component_name = Some(current_root.clone());
+                }
+                unique_roots.insert(current_root);
+
+                // If we find more than one unique root, we can stop early
+                if unique_roots.len() > 1 {
+                    tracing::debug!(
+                        "Multiple top-level items found in TAR {}, cannot infer single root.",
+                        archive_path_for_log.display()
+                    );
+                    return Ok(None);
+                }
+            } else {
+                // Found a non-Normal component at the top level (e.g., .., /)
+                tracing::debug!(
+                    "Non-standard top-level component ({:?}) found in TAR {}, cannot infer single root.",
+                    first_comp, archive_path_for_log.display()
+                );
+                return Ok(None); // Archive is not structured under a single root dir
+            }
+        } else {
+             // Path is empty or unusual, treat as non-standard structure
+             tracing::debug!(
+                 "Empty or unusual path found in TAR {}, cannot infer single root.",
+                  archive_path_for_log.display()
+            );
+            return Ok(None);
+        }
+    }
+
+    // After checking all entries:
+    if unique_roots.len() == 1 && non_empty_entry_found {
+         let inferred_root = first_component_name.unwrap(); // Safe unwrap as len == 1
+         tracing::debug!(
+            "Inferred single root directory in TAR {}: {}",
+             archive_path_for_log.display(), inferred_root.display()
+        );
+        Ok(Some(inferred_root))
+    } else if !non_empty_entry_found {
+        tracing::warn!(
+            "TAR archive {} appears to be empty or contain only metadata.",
+            archive_path_for_log.display());
+        Ok(None) // Empty archive doesn't have a root dir
+    }
+     else {
+        // This case (len == 0 but non_empty_entry_found is true) shouldn't happen
+        // If len > 1, it was handled in the loop
+        tracing::debug!(
+            "No single common root directory found in TAR {}. unique_roots count: {}",
+            archive_path_for_log.display(), unique_roots.len()
+        );
+        Ok(None) // Flat archive or multiple roots
+    }
+}
+
+// Helper for ZIP format
+fn infer_zip_root<R: Read + Seek>(
+    reader: R,
+    archive_path_for_log: &Path,
+) -> Result<Option<PathBuf>> {
+    let mut archive = ZipArchive::new(reader).map_err(|e| {
+        SapphireError::Generic(format!(
+            "Failed to open ZIP {}: {}",
+            archive_path_for_log.display(),
+            e
+        ))
+    })?;
+    let mut unique_roots = HashSet::new();
+    let mut non_empty_entry_found = false;
+    let mut first_component_name: Option<PathBuf> = None;
+
+    for i in 0..archive.len() {
+        let file = archive.by_index_raw(i).map_err(|e| { // Use by_index_raw to avoid full decompression
+            SapphireError::Generic(format!(
+                "Error reading ZIP index {} in {}: {}",
+                i,
+                archive_path_for_log.display(),
+                e
+            ))
+        })?;
+
+        // Use file.name() which is the raw path string from the central directory
+        let path_str = file.name();
+        let path = PathBuf::from(path_str); // Convert raw string to PathBuf
+
+         // Ignore metadata-only entries if they have no components
+        if path.components().next().is_none() {
+            continue;
+        }
+
+
+        if let Some(first_comp) = path.components().next() {
+            if let Component::Normal(name) = first_comp {
+                 non_empty_entry_found = true;
+                 let current_root = PathBuf::from(name);
+                 if first_component_name.is_none() {
+                     first_component_name = Some(current_root.clone());
+                 }
+                 unique_roots.insert(current_root);
+
+
+                if unique_roots.len() > 1 {
+                     tracing::debug!("Multiple top-level items found in ZIP {}, cannot infer single root.", archive_path_for_log.display());
+                    return Ok(None);
+                }
+            } else {
+                 tracing::debug!("Non-standard top-level component ({:?}) found in ZIP {}, cannot infer single root.", first_comp, archive_path_for_log.display());
+                return Ok(None);
+            }
+        } else {
+             tracing::debug!("Empty or unusual path ('{}') found in ZIP {}, cannot infer single root.", path_str, archive_path_for_log.display());
+            return Ok(None);
+        }
+    }
+
+    // After checking all entries:
+    if unique_roots.len() == 1 && non_empty_entry_found {
+        let inferred_root = first_component_name.unwrap(); // Safe unwrap
+         tracing::debug!("Inferred single root directory in ZIP {}: {}", archive_path_for_log.display(), inferred_root.display());
+        Ok(Some(inferred_root))
+    } else if !non_empty_entry_found {
+         tracing::warn!("ZIP archive {} appears to be empty or contain only metadata.", archive_path_for_log.display());
+        Ok(None)
+    }
+    else {
+        tracing::debug!("No single common root directory found in ZIP {}. unique_roots count: {}", archive_path_for_log.display(), unique_roots.len());
+        Ok(None) // Flat archive or multiple roots
+    }
+}
 
 /// Extracts an archive to the target directory using native Rust crates.
 /// Supports `.tar`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, and `.zip`.

--- a/sapphire-core/src/build/formula/source/cmake.rs
+++ b/sapphire-core/src/build/formula/source/cmake.rs
@@ -41,20 +41,19 @@ pub fn cmake_build(
     );
 
     let mut cmd = Command::new(cmake_exe);
-    // Pass "." as the source directory relative to the CWD (which is the actual source root)
-    cmd.arg(".") // <--- CHANGED FROM source_dir_for_build (which was previously passed here)
+    // Pass ".." as the source directory relative to the build_subdir where cmake runs
+    cmd.arg("..") // <--- CORRECTED LINE
         .arg(format!("-DCMAKE_INSTALL_PREFIX={}", install_dir.display()))
-        .arg("-DCMAKE_POLICY_VERSION_MINIMUM=3.5") // Keep this for compatibility
-        .arg("-DCMAKE_BUILD_TYPE=Release") // Add recommended build type
+        .arg("-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+        .arg("-DCMAKE_BUILD_TYPE=Release")
         .args([
             "-G",
-            "Ninja", // Specify Ninja generator
+            "Ninja",
             "-DCMAKE_FIND_FRAMEWORK=LAST",
-            "-DCMAKE_VERBOSE_MAKEFILE=ON", // Verbose output helpful for debugging
-            "-Wno-dev",                    // Suppress developer warnings if needed
+            "-DCMAKE_VERBOSE_MAKEFILE=ON",
+            "-Wno-dev",
         ])
-        // Run from the newly created build subdir
-        .current_dir(&build_subdir);
+        .current_dir(&build_subdir); // Run from the build subdir
 
     build_env.apply_to_command(&mut cmd);
     let output = cmd

--- a/sapphire-core/src/build/formula/source/cmake.rs
+++ b/sapphire-core/src/build/formula/source/cmake.rs
@@ -11,14 +11,21 @@ use crate::utils::error::{Result, SapphireError};
 
 /// Build with CMake, using Ninja as the generator
 pub fn cmake_build(
-    source_dir_for_build: &Path, // Renamed for clarity - path containing main CMakeLists.txt
+    source_dot: &Path, // Parameter represents "." now, as CWD is the source root
     install_dir: &Path,
     build_env: &BuildEnvironment,
 ) -> Result<()> {
+    // Ensure source_dot is actually "."
+    if source_dot != Path::new(".") {
+        return Err(SapphireError::BuildEnvError(format!(
+            "cmake_build expected source path '.' but received '{}'",
+            source_dot.display()
+        )));
+    }
+
     info!("==> Building with CMake");
     let build_subdir_name = "sapphire-cmake-build";
-    // Create the build directory *outside* the source_dir_for_build, typically in the CWD
-    // which is the root build_dir set by the caller (build_from_source)
+    // Create the build directory *outside* the source, relative to CWD
     let build_subdir = Path::new(".").join(build_subdir_name); // Relative to CWD
     fs::create_dir_all(&build_subdir).map_err(SapphireError::Io)?;
 
@@ -34,14 +41,14 @@ pub fn cmake_build(
     );
 
     let mut cmd = Command::new(cmake_exe);
-    // Pass the potentially nested source dir containing the main CMakeLists.txt
-    cmd.arg(source_dir_for_build)
+    // Pass "." as the source directory relative to the CWD (which is the actual source root)
+    cmd.arg(".") // <--- CHANGED FROM source_dir_for_build (which was previously passed here)
         .arg(format!("-DCMAKE_INSTALL_PREFIX={}", install_dir.display()))
         .arg("-DCMAKE_POLICY_VERSION_MINIMUM=3.5") // Keep this for compatibility
-        .arg("-DCMAKE_BUILD_TYPE=Release") // *** Add recommended build type ***
+        .arg("-DCMAKE_BUILD_TYPE=Release") // Add recommended build type
         .args([
             "-G",
-            "Ninja", // *** Specify Ninja generator ***
+            "Ninja", // Specify Ninja generator
             "-DCMAKE_FIND_FRAMEWORK=LAST",
             "-DCMAKE_VERBOSE_MAKEFILE=ON", // Verbose output helpful for debugging
             "-Wno-dev",                    // Suppress developer warnings if needed
@@ -55,6 +62,7 @@ pub fn cmake_build(
         .map_err(|e| SapphireError::CommandExecError(format!("Failed to execute cmake: {}", e)))?;
 
     if !output.status.success() {
+        // (Error handling code from your original file)
         println!("CMake configure failed with status: {}", output.status);
         eprintln!(
             "CMake configure stdout:\n{}",
@@ -64,15 +72,6 @@ pub fn cmake_build(
             "CMake configure stderr:\n{}",
             String::from_utf8_lossy(&output.stderr)
         );
-        // Attempt to read CMakeCache.txt for more clues on failure
-        let cache_log = build_subdir.join("CMakeCache.txt");
-        if cache_log.exists() {
-            eprintln!("--- CMakeCache.txt ---");
-            if let Ok(content) = fs::read_to_string(&cache_log) {
-                eprintln!("{}", content);
-            }
-            eprintln!("--- End CMakeCache.txt ---");
-        }
         let error_log = build_subdir.join("CMakeFiles/CMakeError.log");
         if error_log.exists() {
             eprintln!("--- CMakeFiles/CMakeError.log ---");
@@ -116,6 +115,7 @@ pub fn cmake_build(
     })?;
 
     if !output_install.status.success() {
+        // (Error handling code from your original file)
         println!(
             "Ninja install failed with status: {}",
             output_install.status

--- a/sapphire-core/src/build/formula/source/go.rs
+++ b/sapphire-core/src/build/formula/source/go.rs
@@ -10,20 +10,33 @@ use crate::utils::error::{Result, SapphireError};
 
 /// Build Go project
 pub fn go_build(
-    build_dir: &Path,
+    build_dir_dot: &Path,
     install_dir: &Path,
     build_env: &BuildEnvironment,
     all_installed_paths: &[PathBuf],
 ) -> Result<()> {
+    // Ensure the path passed is actually "."
+    if build_dir_dot != Path::new(".") {
+        return Err(SapphireError::BuildEnvError(format!(
+            "go_build expected build path '.' but received '{}'",
+            build_dir_dot.display()
+        )));
+    }
+
     info!("==> Building with Go build script");
 
-    let (script_to_run, run_in_dir) = if build_dir.join("src/make.bash").exists() {
-        (build_dir.join("src/make.bash"), build_dir.join("src"))
-    } else if build_dir.join("src/all.bash").exists() {
-        (build_dir.join("src/all.bash"), build_dir.join("src"))
+    // Calculate script paths relative to build_dir_dot (which is CWD)
+    let src_dir = build_dir_dot.join("src");
+    let make_bash = src_dir.join("make.bash");
+    let all_bash = src_dir.join("all.bash");
+
+    let (script_to_run, run_in_dir) = if make_bash.exists() {
+        (make_bash, src_dir.clone()) // Script path, directory to run in
+    } else if all_bash.exists() {
+        (all_bash, src_dir.clone())
     } else {
         return Err(SapphireError::Generic(
-            "Go build script (src/make.bash or src/all.bash) not found.".to_string(),
+            "Go build script (src/make.bash or src/all.bash) not found relative to CWD.".to_string(),
         ));
     };
 
@@ -37,41 +50,44 @@ pub fn go_build(
     info!(
         "==> Running {} {} in {}",
         bash_exe.display(),
-        script_to_run.display(),
-        run_in_dir.display()
+        // Display the script path relative to CWD for clarity
+        script_to_run.strip_prefix(build_dir_dot).unwrap_or(&script_to_run).display(),
+        run_in_dir.strip_prefix(build_dir_dot).unwrap_or(&run_in_dir).display()
     );
 
+    // Ensure script is executable
     if cfg!(unix) {
         use std::os::unix::fs::PermissionsExt;
         match fs::metadata(&script_to_run) {
             Ok(metadata) => {
                 let mut perms = metadata.permissions();
                 let original_mode = perms.mode();
+                // Set user execute bit if not already set
                 if original_mode & 0o100 == 0 {
-                    perms.set_mode(original_mode | 0o100);
+                   perms.set_mode(original_mode | 0o100); // Add u+x
                     if let Err(e) = fs::set_permissions(&script_to_run, perms) {
                         warn!(
-                            "Warning: Failed to set executable permission on Go build script: {}",
-                            e
+                            "Warning: Failed to set executable permission on {}: {}",
+                            script_to_run.display(), e
                         );
                     } else {
-                        debug!("Set Go build script executable.");
+                        debug!("Set {} executable.", script_to_run.display());
                     }
                 }
             }
             Err(e) => warn!(
-                "Warning: Failed to read metadata for Go build script: {}",
-                e
+                "Warning: Failed to read metadata for {}: {}",
+                script_to_run.display(), e
             ),
         }
     }
 
+    // Set GOROOT_BOOTSTRAP
     let mut go_build_specific_env = HashMap::new();
     let bootstrap_go_path = all_installed_paths.iter().find(|p| {
         p.file_name()
             .is_some_and(|n| n == "go" || n.to_string_lossy().starts_with("go@"))
     });
-
     if let Some(path) = bootstrap_go_path {
         info!("Found bootstrap Go path: {}", path.display());
         go_build_specific_env.insert(
@@ -83,8 +99,9 @@ pub fn go_build(
     }
 
     let mut cmd = Command::new(bash_exe);
-    cmd.arg(&script_to_run);
-    cmd.current_dir(&run_in_dir);
+    // Pass the relative script path ./src/make.bash etc.
+    cmd.arg(script_to_run.strip_prefix(build_dir_dot).unwrap_or(&script_to_run));
+    cmd.current_dir(&run_in_dir); // Run the script from within the src directory
     build_env.apply_to_command(&mut cmd);
     cmd.envs(&go_build_specific_env);
 
@@ -97,6 +114,7 @@ pub fn go_build(
     })?;
 
     if !output.status.success() {
+        // (Error handling remains the same)
         println!("Go build script failed with status: {}", output.status);
         eprintln!(
             "Go build stdout:\n{}",
@@ -121,17 +139,24 @@ pub fn go_build(
         );
     }
 
+    // Copy artifacts from build_dir_dot (CWD) to install_dir
     info!(
         "==> Installing Go build artifacts to {}",
         install_dir.display()
     );
     fs::create_dir_all(install_dir).map_err(SapphireError::Io)?;
 
-    let go_output_bin_dir = build_dir.join("bin");
-    let go_output_pkg_dir = build_dir.join("pkg");
+    // Source directories are relative to build_dir_dot (CWD)
+    let go_output_bin_dir = build_dir_dot.join("bin");
+    let go_output_pkg_dir = build_dir_dot.join("pkg");
+    let go_output_src_dir = build_dir_dot.join("src"); // This is the src dir relative to CWD
+
+    // Target directories are relative to install_dir
     let target_bin_dir = install_dir.join("bin");
     let target_pkg_dir = install_dir.join("pkg");
+    let target_src_dir = install_dir.join("src");
 
+    // Copy logic remains the same, uses correct source/target paths
     if go_output_bin_dir.is_dir() {
         info!(
             "Copying contents from {} to {}",
@@ -162,22 +187,23 @@ pub fn go_build(
         );
     }
 
-    let go_output_src_dir = build_dir.join("src");
-    if go_output_src_dir.is_dir() {
-        let target_src_dir = install_dir.join("src");
-        info!(
-            "Copying contents from {} to {}",
-            go_output_src_dir.display(),
-            target_src_dir.display()
-        );
-        fs::create_dir_all(&target_src_dir).map_err(SapphireError::Io)?;
-        copy_directory_contents(&go_output_src_dir, &target_src_dir)?;
-    } else {
-        debug!(
-            "Go output src directory not found: {}",
-            go_output_src_dir.display()
-        );
+    // Only copy src if it exists *outside* the install dir already
+    // This prevents recursion if install_dir is inside build_dir_dot somehow
+    if go_output_src_dir.is_dir() && go_output_src_dir != install_dir.join("src") {
+         info!(
+             "Copying contents from {} to {}",
+             go_output_src_dir.display(),
+             target_src_dir.display()
+         );
+         fs::create_dir_all(&target_src_dir).map_err(SapphireError::Io)?;
+         copy_directory_contents(&go_output_src_dir, &target_src_dir)?;
+    } else if !go_output_src_dir.is_dir() {
+         debug!(
+             "Go output src directory not found: {}",
+             go_output_src_dir.display()
+         );
     }
+
 
     Ok(())
 }
@@ -190,14 +216,17 @@ fn copy_directory_contents(from: &Path, to: &Path) -> Result<()> {
         let dest_path = to.join(entry.file_name());
 
         if src_path.is_dir() {
+            // Ensure target subdir exists before recursive call
             fs::create_dir_all(&dest_path).map_err(SapphireError::Io)?;
             copy_directory_contents(&src_path, &dest_path)?;
         } else if src_path.is_file() {
+            // Ensure target dir exists before copying file
             if let Some(parent) = dest_path.parent() {
                 fs::create_dir_all(parent).map_err(SapphireError::Io)?;
             }
             fs::copy(&src_path, &dest_path).map_err(SapphireError::Io)?;
         }
+        // Skip symlinks or handle them explicitly if needed
     }
     Ok(())
 }

--- a/sapphire-core/src/build/formula/source/go.rs
+++ b/sapphire-core/src/build/formula/source/go.rs
@@ -36,7 +36,8 @@ pub fn go_build(
         (all_bash, src_dir.clone())
     } else {
         return Err(SapphireError::Generic(
-            "Go build script (src/make.bash or src/all.bash) not found relative to CWD.".to_string(),
+            "Go build script (src/make.bash or src/all.bash) not found relative to CWD."
+                .to_string(),
         ));
     };
 
@@ -51,8 +52,14 @@ pub fn go_build(
         "==> Running {} {} in {}",
         bash_exe.display(),
         // Display the script path relative to CWD for clarity
-        script_to_run.strip_prefix(build_dir_dot).unwrap_or(&script_to_run).display(),
-        run_in_dir.strip_prefix(build_dir_dot).unwrap_or(&run_in_dir).display()
+        script_to_run
+            .strip_prefix(build_dir_dot)
+            .unwrap_or(&script_to_run)
+            .display(),
+        run_in_dir
+            .strip_prefix(build_dir_dot)
+            .unwrap_or(&run_in_dir)
+            .display()
     );
 
     // Ensure script is executable
@@ -64,11 +71,12 @@ pub fn go_build(
                 let original_mode = perms.mode();
                 // Set user execute bit if not already set
                 if original_mode & 0o100 == 0 {
-                   perms.set_mode(original_mode | 0o100); // Add u+x
+                    perms.set_mode(original_mode | 0o100); // Add u+x
                     if let Err(e) = fs::set_permissions(&script_to_run, perms) {
                         warn!(
                             "Warning: Failed to set executable permission on {}: {}",
-                            script_to_run.display(), e
+                            script_to_run.display(),
+                            e
                         );
                     } else {
                         debug!("Set {} executable.", script_to_run.display());
@@ -77,7 +85,8 @@ pub fn go_build(
             }
             Err(e) => warn!(
                 "Warning: Failed to read metadata for {}: {}",
-                script_to_run.display(), e
+                script_to_run.display(),
+                e
             ),
         }
     }
@@ -100,7 +109,11 @@ pub fn go_build(
 
     let mut cmd = Command::new(bash_exe);
     // Pass the relative script path ./src/make.bash etc.
-    cmd.arg(script_to_run.strip_prefix(build_dir_dot).unwrap_or(&script_to_run));
+    cmd.arg(
+        script_to_run
+            .strip_prefix(build_dir_dot)
+            .unwrap_or(&script_to_run),
+    );
     cmd.current_dir(&run_in_dir); // Run the script from within the src directory
     build_env.apply_to_command(&mut cmd);
     cmd.envs(&go_build_specific_env);
@@ -190,20 +203,19 @@ pub fn go_build(
     // Only copy src if it exists *outside* the install dir already
     // This prevents recursion if install_dir is inside build_dir_dot somehow
     if go_output_src_dir.is_dir() && go_output_src_dir != install_dir.join("src") {
-         info!(
-             "Copying contents from {} to {}",
-             go_output_src_dir.display(),
-             target_src_dir.display()
-         );
-         fs::create_dir_all(&target_src_dir).map_err(SapphireError::Io)?;
-         copy_directory_contents(&go_output_src_dir, &target_src_dir)?;
+        info!(
+            "Copying contents from {} to {}",
+            go_output_src_dir.display(),
+            target_src_dir.display()
+        );
+        fs::create_dir_all(&target_src_dir).map_err(SapphireError::Io)?;
+        copy_directory_contents(&go_output_src_dir, &target_src_dir)?;
     } else if !go_output_src_dir.is_dir() {
-         debug!(
-             "Go output src directory not found: {}",
-             go_output_src_dir.display()
-         );
+        debug!(
+            "Go output src directory not found: {}",
+            go_output_src_dir.display()
+        );
     }
-
 
     Ok(())
 }

--- a/sapphire-core/src/build/formula/source/meson.rs
+++ b/sapphire-core/src/build/formula/source/meson.rs
@@ -8,13 +8,22 @@ use crate::utils::error::{Result, SapphireError};
 
 /// Build with Meson
 pub fn meson_build(
-    source_dir: &Path,
+    source_dot: &Path, // Parameter represents "." now, as CWD is the source root
     install_dir: &Path,
     build_env: &BuildEnvironment,
 ) -> Result<()> {
+    // Ensure source_dot is actually "."
+    if source_dot != Path::new(".") {
+        return Err(SapphireError::BuildEnvError(format!(
+            "meson_build expected source path '.' but received '{}'",
+            source_dot.display()
+        )));
+    }
+
     info!("==> Building with Meson");
     let build_subdir_name = "sapphire-meson-build";
-    let build_subdir = source_dir.join(build_subdir_name);
+    // Meson prefers the build directory passed as an argument, relative to CWD
+    let build_subdir = Path::new(".").join(build_subdir_name);
 
     let meson_exe =
         which::which_in("meson", build_env.get_path_string(), Path::new(".")).map_err(|_| {
@@ -26,8 +35,8 @@ pub fn meson_build(
         "==> Running meson setup: {} setup --prefix={} {} {}",
         meson_exe.display(),
         install_dir.display(),
-        build_subdir.display(),
-        source_dir.display()
+        build_subdir.display(), // Build directory
+        "." // Source directory (CWD) <-- CHANGED from source_dir
     );
 
     let mut cmd_setup = Command::new(&meson_exe);
@@ -36,14 +45,16 @@ pub fn meson_build(
         .arg(format!("--prefix={}", install_dir.display()))
         .arg("--buildtype=release")
         .arg("--libdir=lib")
-        .arg(&build_subdir)
-        .arg(".");
+        .arg(&build_subdir) // Specify build directory
+        .arg("."); // Specify source directory (CWD) <-- CHANGED from source_dir
     build_env.apply_to_command(&mut cmd_setup);
+    // Meson setup runs from the CWD (which is the source root)
     let output_setup = cmd_setup.output().map_err(|e| {
         SapphireError::CommandExecError(format!("Failed to execute meson setup: {}", e))
     })?;
 
     if !output_setup.status.success() {
+        // (Error handling code from your original file)
         println!("Meson setup failed with status: {}", output_setup.status);
         eprintln!(
             "Meson setup stdout:\n{}",
@@ -68,18 +79,22 @@ pub fn meson_build(
         );
     }
 
+    // Check for ninja before attempting install
     let _ninja_exe = which::which_in("ninja", build_env.get_path_string(), Path::new("."))
         .map_err(|_| SapphireError::BuildEnvError("ninja command not found (needed for meson install). Ensure ninja is installed and in build dependencies.".to_string()))?;
-    info!("==> Running meson install -C {}", build_subdir.display());
 
+    // Meson install uses -C to specify the build directory
+    info!("==> Running meson install -C {}", build_subdir.display());
     let mut cmd_install = Command::new(&meson_exe);
-    cmd_install.arg("install").arg("-C").arg(&build_subdir);
+    cmd_install.arg("install").arg("-C").arg(&build_subdir); // Use -C flag
     build_env.apply_to_command(&mut cmd_install);
+    // Install command also runs from the CWD (source root)
     let output_install = cmd_install.output().map_err(|e| {
         SapphireError::CommandExecError(format!("Failed to execute meson install: {}", e))
     })?;
 
     if !output_install.status.success() {
+        // (Error handling code from your original file)
         println!(
             "Meson install failed with status: {}",
             output_install.status

--- a/sapphire-core/src/build/formula/source/meson.rs
+++ b/sapphire-core/src/build/formula/source/meson.rs
@@ -36,7 +36,7 @@ pub fn meson_build(
         meson_exe.display(),
         install_dir.display(),
         build_subdir.display(), // Build directory
-        "." // Source directory (CWD) <-- CHANGED from source_dir
+        "."                     // Source directory (CWD) <-- CHANGED from source_dir
     );
 
     let mut cmd_setup = Command::new(&meson_exe);

--- a/sapphire-core/src/build/formula/source/mod.rs
+++ b/sapphire-core/src/build/formula/source/mod.rs
@@ -2,18 +2,16 @@
 
 // --- Imports ---
 use std::collections::HashMap;
-use std::ffi::OsString;
 use std::fs::{self};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::Command;
 
 use futures::future::try_join_all;
 use infer;
 use tracing::{debug, error, info, warn};
-use walkdir::WalkDir;
 
 use crate::build::env::BuildEnvironment;
-use crate::build::extract::extract_archive;
+use crate::build::extract;
 use crate::fetch::http as http_fetch;
 use crate::model::formula::{Formula, FormulaDependencies, ResourceSpec};
 use crate::utils::config::Config;
@@ -42,118 +40,6 @@ const SUPPORTED_ARCHIVE_EXTENSIONS: [&str; 5] = ["gz", "bz2", "xz", "tar", "zip"
 const RECOGNISED_SINGLE_FILE_EXTENSIONS: [&str; 9] =
     ["tar", "gz", "tgz", "bz2", "tbz", "tbz2", "xz", "txz", "zip"];
 
-// --- Helper Functions ---
-
-/// Creates a directory and all its parents, mapping IO errors with context.
-fn create_dir_all_with_context(path: &Path, context: &str) -> Result<()> {
-    fs::create_dir_all(path).map_err(|e| {
-        SapphireError::Io(std::io::Error::new(
-            e.kind(),
-            format!("Failed to create {} {}: {}", context, path.display(), e),
-        ))
-    })
-}
-
-/// Executes a command, checks status, and returns a detailed error on failure.
-fn run_command(cmd: &mut Command, context: &str) -> Result<Output> {
-    debug!("Running command ({}): {:?}", context, cmd);
-    let output = cmd.output().map_err(|e| {
-        SapphireError::CommandExecError(format!("Failed to execute command for {}: {}", context, e))
-    })?;
-
-    if !output.status.success() {
-        error!("Command failed for {}. Status: {}", context, output.status);
-        error!("Stdout:\n{}", String::from_utf8_lossy(&output.stdout));
-        error!("Stderr:\n{}", String::from_utf8_lossy(&output.stderr));
-        Err(SapphireError::CommandExecError(format!(
-            "Command failed during {} stage. Status: {}",
-            context, output.status
-        )))
-    } else {
-        debug!("Command successful for {}", context);
-        debug!("Stdout:\n{}", String::from_utf8_lossy(&output.stdout));
-        debug!("Stderr:\n{}", String::from_utf8_lossy(&output.stderr));
-        Ok(output)
-    }
-}
-
-/// Tries to infer archive type, falls back to extension, and validates.
-fn determine_archive_type(archive_path: &Path, context: &str) -> Result<&'static str> {
-    match infer::get_from_path(archive_path)? {
-        // Handles infer's IO error
-        Some(kind) => {
-            let ext = kind.extension();
-            debug!("Inferred archive type for {}: {}", context, ext);
-            if SUPPORTED_ARCHIVE_EXTENSIONS.contains(&ext) {
-                Ok(ext)
-            } else {
-                error!(
-                    "Unsupported inferred archive type '{}' for {}: {}",
-                    ext,
-                    context,
-                    archive_path.display()
-                );
-                Err(SapphireError::Generic(format!(
-                    "Unsupported inferred archive type '{}' for {}: {}",
-                    ext,
-                    context,
-                    archive_path.display()
-                )))
-            }
-        }
-        None => {
-            // Fallback to extension if infer fails
-            let fallback_ext = archive_path
-                .extension()
-                .and_then(|s| s.to_str())
-                .unwrap_or("");
-            warn!(
-                "Could not infer archive type for {}, falling back to extension '{}'.",
-                archive_path.display(),
-                fallback_ext
-            );
-            if fallback_ext.is_empty() {
-                error!(
-                    "Cannot determine archive type for {}: {}",
-                    context,
-                    archive_path.display()
-                );
-                return Err(SapphireError::Generic(format!(
-                    "Cannot determine archive type for {}: {}",
-                    context,
-                    archive_path.display()
-                )));
-            }
-            // Check if fallback is supported
-            if SUPPORTED_ARCHIVE_EXTENSIONS.contains(&fallback_ext) {
-                // We need to return a &'static str. Find the matching static string.
-                SUPPORTED_ARCHIVE_EXTENSIONS
-                    .iter()
-                    .find(|&&s| s == fallback_ext)
-                    .copied()
-                    .ok_or_else(|| {
-                        SapphireError::Generic(format!(
-                            "Internal error: Matched extension '{}' not found in static list",
-                            fallback_ext
-                        ))
-                    }) // Should not happen
-            } else {
-                error!(
-                    "Unsupported fallback archive type '{}' for {}: {}",
-                    fallback_ext,
-                    context,
-                    archive_path.display()
-                );
-                Err(SapphireError::Generic(format!(
-                    "Unsupported fallback archive type '{}' for {}: {}",
-                    fallback_ext,
-                    context,
-                    archive_path.display()
-                )))
-            }
-        }
-    }
-}
 
 // --- download_source ---
 pub async fn download_source(formula: &Formula, config: &Config) -> Result<PathBuf> {
@@ -190,9 +76,199 @@ pub async fn download_source(formula: &Formula, config: &Config) -> Result<PathB
     .await
 }
 
+/// Restores the original working directory when dropped (RAII).
+struct CurrentWorkingDirectoryGuard {
+    original_cwd: PathBuf,
+}
+impl CurrentWorkingDirectoryGuard {
+    fn new(original_cwd: PathBuf) -> Self {
+        Self { original_cwd }
+    }
+}
+impl Drop for CurrentWorkingDirectoryGuard {
+    fn drop(&mut self) {
+        if let Err(e) = std::env::set_current_dir(&self.original_cwd) {
+            error!(
+                "Failed to restore original working directory to {}: {}",
+                self.original_cwd.display(),
+                e
+            );
+        } else {
+            debug!(
+                "Restored working directory to: {}",
+                self.original_cwd.display()
+            );
+        }
+    }
+}
+
+// --- Helper Functions (ensure these are present or imported) ---
+fn create_dir_all_with_context(path: &Path, context: &str) -> Result<()> {
+    fs::create_dir_all(path).map_err(|e| {
+        SapphireError::Io(std::io::Error::new(
+            e.kind(),
+            format!("Failed to create {} {}: {}", context, path.display(), e),
+        ))
+    })
+}
+
+fn run_command(cmd: &mut Command, context: &str) -> Result<std::process::Output> {
+    debug!("Running command ({}): {:?}", context, cmd);
+    let output = cmd.output().map_err(|e| {
+        SapphireError::CommandExecError(format!("Failed to execute command for {}: {}", context, e))
+    })?;
+
+    if !output.status.success() {
+        error!("Command failed for {}. Status: {}", context, output.status);
+        error!("Stdout:\n{}", String::from_utf8_lossy(&output.stdout));
+        error!("Stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+        Err(SapphireError::CommandExecError(format!(
+            "Command failed during {} stage. Status: {}",
+            context, output.status
+        )))
+    } else {
+        debug!("Command successful for {}", context);
+        // Optionally log stdout/stderr on success if needed at debug level
+        Ok(output)
+    }
+}
+
+/// Detects the build system based on marker files *in the current working directory*
+/// and dispatches to the appropriate build function.
+fn detect_and_build_in_cwd(
+    _formula: &Formula, // <--- Prefixed
+    install_dir: &Path,
+    build_env: &BuildEnvironment,
+    all_installed_paths: &[PathBuf],
+) -> Result<()> {
+    info!("Attempting to detect build system in current directory (CWD)");
+
+    // Order matters for priority (e.g., handle configure before simple Makefile)
+    if Path::new("configure").exists() {
+        info!("Detected build system: Autotools (configure script)");
+        return make::configure_and_make(install_dir, build_env);
+    }
+    if Path::new("CMakeLists.txt").exists() {
+        info!("Detected build system: CMake");
+        return cmake::cmake_build(Path::new("."), install_dir, build_env);
+    }
+    if Path::new("meson.build").exists() {
+        info!("Detected build system: Meson");
+        return meson::meson_build(Path::new("."), install_dir, build_env);
+    }
+    // Check for Perl *before* Python/setup.py as some Perl modules might have setup.py
+    if Path::new("Makefile.PL").exists() || Path::new("Configure").exists() {
+        info!("Detected build system: Perl (Makefile.PL or Configure)");
+        return perl::perl_build(Path::new("."), install_dir, build_env);
+    }
+    if Path::new("Cargo.toml").exists() {
+        info!("Detected build system: Rust/Cargo");
+        return cargo::cargo_build(install_dir, build_env);
+    }
+    if Path::new("setup.py").exists() {
+        info!("Detected build system: Python setup.py");
+        return python::python_build(install_dir, build_env);
+    }
+    let go_src_dir = Path::new("src");
+    if go_src_dir.is_dir()
+        && (go_src_dir.join("make.bash").exists() || go_src_dir.join("all.bash").exists())
+    {
+        info!("Detected Go build system (make.bash or all.bash)");
+        return go::go_build(Path::new("."), install_dir, build_env, all_installed_paths);
+    }
+    if Path::new("Makefile").exists() || Path::new("makefile").exists() {
+        info!("Detected build system: Simple Makefile");
+        return make::simple_make(install_dir, build_env);
+    }
+
+    error!("Could not determine build system in current directory (CWD)");
+    Err(SapphireError::Generic(
+        "Could not determine build system in source directory.".to_string(),
+    ))
+}
+
+fn determine_archive_type(archive_path: &Path, _context: &str) -> Result<&'static str> { // <-- Prefixed
+    match infer::get_from_path(archive_path)? {
+        Some(kind) => {
+            let ext = kind.extension();
+            // Use the constant defined earlier
+            if SUPPORTED_ARCHIVE_EXTENSIONS.contains(&ext) {
+                SUPPORTED_ARCHIVE_EXTENSIONS.iter().find(|&&s| s == ext).copied().ok_or_else(|| {
+                    SapphireError::Generic(format!(
+                        "Internal error matching inferred extension {}",
+                        ext
+                    ))
+                })
+            } else {
+                Err(SapphireError::Generic(format!(
+                    "Unsupported inferred archive type '{}' for {}",
+                    ext, archive_path.display() // Add path for context
+                )))
+            }
+        }
+        None => {
+            let ext = archive_path
+                .extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("");
+            if SUPPORTED_ARCHIVE_EXTENSIONS.contains(&ext) {
+                 SUPPORTED_ARCHIVE_EXTENSIONS.iter().find(|&&s| s == ext).copied().ok_or_else(|| {
+                    SapphireError::Generic(format!(
+                        "Internal error matching file extension {}",
+                        ext
+                    ))
+                })
+            } else {
+                Err(SapphireError::Generic(format!(
+                    "Unsupported file extension '{}' for {}",
+                    ext, archive_path.display() // Add path for context
+                )))
+            }
+        }
+    }
+}
+
+fn install_resource(
+    resource: &ResourceSpec,
+    stage_path: &Path,   // Directory where resource was extracted
+    libexec_path: &Path, // Base libexec path (e.g., <prefix>/libexec)
+    build_env: &BuildEnvironment,
+) -> Result<()> {
+    let original_cwd = std::env::current_dir().map_err(SapphireError::Io)?;
+    debug!(
+        "Changing CWD for resource '{}' install: {}",
+        resource.name,
+        stage_path.display()
+    );
+    std::env::set_current_dir(stage_path).map_err(SapphireError::Io)?;
+    // Use RAII guard to ensure CWD restoration even on errors
+    let _cwd_guard = CurrentWorkingDirectoryGuard::new(original_cwd);
+
+    // Check for build files within the staged resource directory
+    // Prioritize Perl check if both Makefile.PL and setup.py might exist
+    if stage_path.join("Makefile.PL").exists() { // Check for Perl first
+        info!("   -> Detected Perl resource '{}', installing...", resource.name);
+        // Call the function to handle Perl resource installation
+        install_perl_resource(resource, libexec_path, build_env)?;
+    } else if stage_path.join("setup.py").exists() { // Check for Python next
+        info!("   -> Detected Python resource '{}', installing...", resource.name);
+         // Call the function to handle Python resource installation
+        install_python_resource(resource, libexec_path, build_env)?;
+    } else {
+        // We could potentially add more resource build system detections here
+        // (e.g., simple make install)
+        warn!(
+            "   -> Could not detect known build system (Perl/Python) for resource '{}' in {}. Skipping install.",
+            resource.name,
+            stage_path.display()
+        );
+    }
+    Ok(()) // CWD is restored when _cwd_guard goes out of scope
+}
+
 // --- build_from_source ---
 pub async fn build_from_source(
-    source_path: &Path,
+    source_path: &Path, // Path to the downloaded archive
     formula: &Formula,
     config: &Config,
     all_installed_paths: &[PathBuf],
@@ -200,20 +276,44 @@ pub async fn build_from_source(
     let install_dir = formula.install_prefix(&config.cellar)?;
     let formula_name = formula.name();
 
-    // Single file installation check
     let source_extension = source_path
-        .extension()
-        .and_then(|s| s.to_str())
-        .unwrap_or("");
-    if !RECOGNISED_SINGLE_FILE_EXTENSIONS.contains(&source_extension) {
-        info!("==> Installing single file formula: {}", formula_name);
-        create_dir_all_with_context(&install_dir, "install directory")?;
-        install_single_file(source_path, formula, &install_dir)?;
-        crate::build::write_receipt(formula, &install_dir)?;
-        return Ok(install_dir);
-    }
+    .extension()
+    .and_then(|s| s.to_str())
+    .unwrap_or("");
 
-    // Archive Installation Setup
+    // Check if the extension indicates it's NOT a recognized archive type
+    // If it's not a known archive, assume it's a single file to be installed directly.
+    if !RECOGNISED_SINGLE_FILE_EXTENSIONS.contains(&source_extension) {
+    info!("==> Installing single file formula: {}", formula_name);
+    create_dir_all_with_context(&install_dir, "install directory")?;
+    // Call the function that handles copying the single file
+    install_single_file(source_path, formula, &install_dir)?;
+    // Write the receipt and finish early for single files
+    crate::build::write_receipt(formula, &install_dir)?;
+    return Ok(install_dir);
+}
+
+    // --- Determine Archive Type and Infer Root ---
+    // (Assuming source_path is guaranteed to be an archive now,
+    // single file check might be moved before calling build_from_source if needed)
+    let source_archive_type_str =
+        determine_archive_type(source_path, "main source archive")?; // Use existing helper
+
+    // Infer the root directory *before* extraction
+    let inferred_root_dir =
+        extract::infer_archive_root_dir(source_path, source_archive_type_str)?;
+
+    let strip_components = if inferred_root_dir.is_some() {
+        // If a single root dir exists, strip it during extraction
+        tracing::debug!("Detected single root dir in archive, will use strip_components=1.");
+        1
+    } else {
+        // If archive is flat or has multiple roots, don't strip
+        tracing::debug!("Archive is flat or has multiple roots, using strip_components=0.");
+        0
+    };
+
+    // --- Staging Area Setup ---
     let temp_dir_base = config.cache_dir.join("build-temp");
     create_dir_all_with_context(&temp_dir_base, "build temp base")?;
     let temp_build_dir = tempfile::Builder::new()
@@ -226,19 +326,27 @@ pub async fn build_from_source(
                 e
             ))
         })?;
-    let build_dir = temp_build_dir.path();
+    let build_dir = temp_build_dir.path(); // This is where files will land after stripping
 
+    // --- Extract with calculated strip_components ---
     info!(
-        "==> Extracting main source {} to {}",
+        "==> Extracting main source {} to {} (strip_components={})",
         source_path.display(),
-        build_dir.display()
+        build_dir.display(),
+        strip_components
     );
-    let source_archive_type_str = determine_archive_type(source_path, "main source")?;
-    extract_archive(source_path, build_dir, 1, source_archive_type_str)?; // strip_components = 1
+    // Call the existing extract_archive function (ensure it's in scope, maybe crate::build::extract::extract_archive)
+    crate::build::extract::extract_archive(
+        source_path,
+        build_dir,
+        strip_components,
+        source_archive_type_str,
+    )?;
     debug!("==> Extracted main source to {}", build_dir.display());
 
-    // Resource Handling
-    let resources = formula.resources()?;
+
+    // --- Resource Handling (remains the same) ---
+    let resources = formula.resources()?; // Assume this returns Vec<ResourceSpec>
     let mut resource_stage_paths = HashMap::new();
 
     if !resources.is_empty() {
@@ -277,12 +385,13 @@ pub async fn build_from_source(
                 &resource_archive_path,
                 &format!("resource '{}'", res_name),
             )?;
-            extract_archive(
-                &resource_archive_path,
-                &stage_path,
-                0,
-                resource_archive_type_str,
-            )?; // strip_components = 0
+            // Resources are typically extracted without stripping components
+             crate::build::extract::extract_archive(
+                 &resource_archive_path,
+                 &stage_path,
+                 0, // strip_components = 0 for resources
+                 resource_archive_type_str,
+             )?;
             resource_stage_paths.insert(res_name, stage_path);
         }
     }
@@ -290,10 +399,10 @@ pub async fn build_from_source(
     info!(
         "==> Building {} from source in {}",
         formula_name,
-        build_dir.display()
+        build_dir.display() // Build happens directly in the temp dir now
     );
 
-    // Build Environment Setup
+    // --- Build Environment Setup (remains the same) ---
     info!("==> Setting up build environment");
     let sapphire_prefix = config.prefix();
     let build_env = BuildEnvironment::new(
@@ -303,16 +412,38 @@ pub async fn build_from_source(
         all_installed_paths,
     )?;
 
-    // Build Process (with CWD management)
+    // --- Build Process (with CWD management) ---
     let original_cwd = std::env::current_dir().map_err(SapphireError::Io)?;
     info!(
         "Changing working directory to build dir: {}",
         build_dir.display()
     );
     std::env::set_current_dir(build_dir).map_err(SapphireError::Io)?;
-    let _cwd_guard = CurrentWorkingDirectoryGuard::new(original_cwd.clone()); // RAII guard
+    // RAII guard ensures CWD is restored even if subsequent steps panic or return Err
+    let _cwd_guard = CurrentWorkingDirectoryGuard::new(original_cwd.clone());
 
-    // Install Resources First (if any)
+    // --- Autoreconf Check (remains the same) ---
+    if (Path::new("configure.ac").exists() || Path::new("configure.in").exists())
+        && !Path::new("configure").exists()
+    {
+        match which::which_in("autoreconf", build_env.get_path_string(), Path::new(".")) {
+            Ok(autoreconf_path) => {
+                info!("==> Running autoreconf -fvi (as configure script is missing)");
+                let mut cmd = Command::new(autoreconf_path);
+                cmd.args(["-fvi"]);
+                build_env.apply_to_command(&mut cmd);
+                match run_command(&mut cmd, "autoreconf") {
+                    Ok(_) => info!("Autoreconf completed successfully."),
+                    Err(e) => warn!("Autoreconf failed ({}). Continuing build detection...", e),
+                }
+            }
+            Err(_) => {
+                warn!("configure.ac/in found but configure script and autoreconf command are missing.");
+            }
+        }
+    }
+
+    // --- Install Resources First (remains the same) ---
     if !resources.is_empty() {
         info!("==> Installing {} resources into libexec", resources.len());
         let libexec_path = install_dir.join("libexec");
@@ -322,13 +453,10 @@ pub async fn build_from_source(
             if let Some(stage_path) = resource_stage_paths.get(&resource.name) {
                 info!(" --> Installing resource: {}", resource.name);
                 // install_resource changes CWD, ensure build_dir is restored afterward
-                let build_dir_cwd = std::env::current_dir().map_err(SapphireError::Io)?;
+                // let build_dir_cwd = std::env::current_dir().map_err(SapphireError::Io)?; // Not needed due to guard
+                 // install_resource needs to be called within the context of the _cwd_guard
                 install_resource(resource, stage_path, &libexec_path, &build_env)?;
-                info!(
-                    "Restoring working directory after resource install: {}",
-                    build_dir_cwd.display()
-                );
-                std::env::set_current_dir(build_dir_cwd).map_err(SapphireError::Io)?;
+                 // No need to manually restore CWD here, the guard handles it.
             } else {
                 warn!(
                     "Could not find stage path for resource '{}'. Skipping installation.",
@@ -338,360 +466,23 @@ pub async fn build_from_source(
         }
     }
 
-    // Build Main Formula
-    info!("==> Building main formula: {}", formula_name);
-    detect_and_build(
+    // --- Build Main Formula using simplified detection ---
+    info!("==> Detecting build system and building main formula: {}", formula_name);
+    // CWD is now guaranteed to be the source root directory
+    detect_and_build_in_cwd(
         formula,
-        build_dir, // Pass the root build dir
         &install_dir,
         &build_env,
-        all_installed_paths,
+        all_installed_paths, // Keep passing this for Go build
     )?;
 
-    // Post-Install (CWD restored by _cwd_guard dropping)
-    // No need to set CWD back manually here if _cwd_guard is used correctly.
-    // std::env::set_current_dir(original_cwd).map_err(SapphireError::Io)?; // This is redundant
-    crate::build::write_receipt(formula, &install_dir)?;
+    // --- Post-Install (CWD restored by _cwd_guard dropping) ---
+    crate::build::write_receipt(formula, &install_dir)?; // Ensure write_receipt is available
     info!(
         "Build completed, temporary directory {} will be cleaned up.",
         build_dir.display()
     );
     Ok(install_dir)
-}
-
-// --- detect_and_build ---
-fn detect_and_build(
-    formula: &Formula,
-    build_dir: &Path, // Root of extracted source (e.g., .../llvm@19-Vrwnv2/)
-    install_dir: &Path,
-    build_env: &BuildEnvironment,
-    all_installed_paths: &[PathBuf],
-) -> Result<()> {
-    info!(
-        "Attempting to detect build system in: {}",
-        build_dir.display()
-    );
-
-    // Marker format: (filename, system_name, requires_root_dir_detection)
-    // requires_root_dir_detection: true if we generally expect this marker ONLY at the root.
-    let markers: &[(&str, &str, bool)] = &[
-        ("configure", "Autotools (configure script)", true), // Must be at root
-        ("CMakeLists.txt", "CMake", false),                  // Can be nested
-        ("meson.build", "Meson", false),                     // Can be nested
-        ("Makefile.PL", "Perl (Makefile.PL)", true),         // Must be at root
-        ("Configure", "Perl (Configure)", true),             // Must be at root
-        ("Cargo.toml", "Rust/Cargo", true),                  // Must be at root
-        ("setup.py", "Python setup.py", true),               // Must be at root
-        ("Makefile", "Makefile", true),                      // Must be at root
-        ("makefile", "Makefile", true),                      // Must be at root
-    ];
-
-    // --- Special case checks first ---
-
-    // Handle autoreconf possibility if configure script is missing but .ac/.in exists
-    if (build_dir.join("configure.ac").exists() || build_dir.join("configure.in").exists())
-        && !build_dir.join("configure").exists()
-    {
-        match which::which_in("autoreconf", build_env.get_path_string(), build_dir) {
-            Ok(autoreconf_path) => {
-                info!("==> Running autoreconf -fvi (as configure script is missing)");
-                let mut cmd = Command::new(autoreconf_path);
-                cmd.args(["-fvi"]);
-                build_env.apply_to_command(&mut cmd);
-                // Use helper, but only warn on failure, don't stop detection
-                match run_command(&mut cmd, "autoreconf") {
-                    Ok(_) => info!("Autoreconf completed successfully."),
-                    Err(e) => warn!("Autoreconf failed ({}). Continuing detection...", e),
-                }
-            }
-            Err(_) => {
-                warn!("configure.ac/in found but configure script and autoreconf command are missing.");
-            }
-        }
-    }
-
-    // Handle Go structure (special case not based on single marker file)
-    let go_src_dir = build_dir.join("src");
-    if go_src_dir.is_dir()
-        && (go_src_dir.join("make.bash").exists() || go_src_dir.join("all.bash").exists())
-    {
-        info!("Detected Go build system (make.bash or all.bash)");
-        // Go build usually expects to run from the root of the extracted source
-        return go::go_build(build_dir, install_dir, build_env, all_installed_paths);
-    }
-
-    // --- Search for markers ---
-    // Stores best match: (marker_filename, marker_containing_dir_path, depth, score)
-    let mut best_match: Option<(String, PathBuf, usize, i32)> = None;
-    let base_formula_name = formula
-        .name()
-        .split('@')
-        .next()
-        .unwrap_or_else(|| formula.name());
-    let preferred_subdirs: Vec<OsString> = vec![
-        OsString::from("src"),
-        OsString::from("source"),
-        OsString::from(base_formula_name), // e.g., "llvm" for "llvm@19"
-    ];
-
-    // Iterate through directories using WalkDir, limiting depth
-    for entry_result in WalkDir::new(build_dir)
-        .min_depth(0) // Start from root
-        .max_depth(2) // Check root, depth 1, depth 2
-        .into_iter()
-        .filter_map(|e| e.ok())
-    // Filter out errors during walk
-    {
-        let current_path = entry_result.path(); // Path to the file/directory entry
-        let current_depth = entry_result.depth();
-
-        if current_path.is_file() {
-            let file_name_os = entry_result.file_name();
-            let file_name = file_name_os.to_str().unwrap_or("");
-            let parent_dir = current_path.parent().unwrap_or(build_dir); // Dir containing the file
-
-            // Find if this filename is a known marker
-            if let Some((marker, _system_name, requires_root)) =
-                markers.iter().find(|(m, _, _)| *m == file_name)
-            {
-                if *requires_root && current_depth > 1 {
-                    debug!(
-                        "Skipping root marker '{}' found at depth {}, requires depth 1.",
-                        marker, current_depth
-                    );
-                    continue;
-                }
-
-                // (Adjust scoring to strongly prefer depth 1 for root markers)
-                let mut score = match current_depth {
-                    1 => {
-                        // Directly inside build_dir (this is the expected root)
-                        if *requires_root {
-                            5
-                        }
-                        // Highest score for root markers here
-                        else {
-                            3
-                        } // Moderate score for non-root markers (CMake/Meson) found flat
-                    }
-                    2 => {
-                        // Inside a subdirectory
-                        if !*requires_root {
-                            // Only score non-root markers here
-                            let parent_dir_name = parent_dir.file_name().map(|f| f.to_os_string());
-                            if parent_dir_name.is_some_and(|name| preferred_subdirs.contains(&name))
-                            {
-                                4 // High score for non-root markers in preferred subdirs
-                            } else {
-                                2 // Lower score for non-root markers in other subdirs
-                            }
-                        } else {
-                            continue; // Don't score root markers found deeper than depth 1
-                        }
-                    }
-                    _ => continue, // Ignore depth 0 (the directory itself) or > 2
-                };
-
-                // Adjust score based on depth (prefer shallower for same base score)
-                score -= current_depth as i32;
-
-                // Marker list priority (lower index = higher priority)
-                let current_priority = markers
-                    .iter()
-                    .position(|(m, _, _)| m == marker)
-                    .unwrap_or(usize::MAX);
-
-                // --- Update best match ---
-                let is_better = match best_match {
-                    None => true,
-                    Some((_, _, _, existing_score)) if score > existing_score => true,
-                    Some((ref existing_marker, _, _, existing_score))
-                        if score == existing_score =>
-                    {
-                        let existing_priority = markers
-                            .iter()
-                            .position(|(m, _, _)| m == existing_marker)
-                            .unwrap_or(usize::MAX);
-                        current_priority < existing_priority // Better priority at same score
-                    }
-                    _ => false, // Not better
-                };
-
-                if is_better {
-                    debug!(
-                        "Updating best match: '{}' in {} (depth {}, score {}, priority {})",
-                        marker,
-                        parent_dir.display(),
-                        current_depth,
-                        score,
-                        current_priority
-                    );
-                    best_match = Some((
-                        marker.to_string(),
-                        parent_dir.to_path_buf(), // Store dir *containing* marker
-                        current_depth,
-                        score,
-                    ));
-                }
-            }
-        }
-    }
-
-    // --- Dispatch based on the best match found ---
-    if let Some((marker_name, marker_dir, depth, score)) = best_match {
-        let system_name = markers
-            .iter()
-            .find(|(m, _, _)| m == &marker_name)
-            .map(|(_, sn, _)| *sn)
-            .unwrap_or("Unknown");
-
-        info!(
-            "Detected build system '{}' (marker: '{}', score: {}) in {} (depth: {})",
-            system_name,
-            marker_name,
-            score,
-            marker_dir.display(), // Log the directory *containing* the marker
-            depth
-        );
-
-        // Determine the effective source directory for the build command
-        // Most build systems run from the root of the extracted archive.
-        // CMake and Meson are exceptions; they need the directory containing the marker file.
-        let source_path_for_build =
-            if depth > 0 && (marker_name == "CMakeLists.txt" || marker_name == "meson.build") {
-                info!(
-                    "Using nested marker directory for build: {}",
-                    marker_dir.display()
-                );
-                marker_dir.as_path()
-            } else {
-                // Default to the root build directory for root markers or other (unexpected) nested
-                // ones.
-                info!(
-                    "Using root build directory for build: {}",
-                    build_dir.display()
-                );
-                build_dir
-            };
-
-        return dispatch_build(
-            &marker_name,
-            source_path_for_build, // Pass the determined source path
-            install_dir,
-            build_env,
-            all_installed_paths,
-        );
-    }
-
-    // --- If no build system detected ---
-    error!(
-        "Could not determine build system for {}",
-        build_dir.display()
-    );
-    Err(SapphireError::Generic(format!(
-        "Could not determine build system for {}",
-        build_dir.display()
-    )))
-}
-
-// --- dispatch_build ---
-fn dispatch_build(
-    marker_filename: &str,
-    source_dir_for_build: &Path, // Path build func should use (might be root or nested)
-    install_dir: &Path,
-    build_env: &BuildEnvironment,
-    _all_installed_paths: &[PathBuf], /* Keep in case Go needs it, though it's handled
-                                       * separately now */
-) -> Result<()> {
-    // Remember: The *current working directory* for dispatch_build is still the root `build_dir`.
-    // The build functions themselves might change CWD or operate relative to
-    // `source_dir_for_build`.
-    match marker_filename {
-        "configure" => {
-            info!("Dispatching to Autotools (configure script)");
-            // configure_and_make assumes it runs ./configure from the CWD (which is root build_dir)
-            make::configure_and_make(install_dir, build_env)
-        }
-        "CMakeLists.txt" => {
-            info!("Dispatching to CMake");
-            // cmake_build needs the path containing CMakeLists.txt
-            cmake::cmake_build(source_dir_for_build, install_dir, build_env)
-        }
-        "meson.build" => {
-            info!("Dispatching to Meson");
-            // meson_build needs the path containing meson.build
-            meson::meson_build(source_dir_for_build, install_dir, build_env)
-        }
-        "Makefile.PL" | "Configure" => {
-            info!("Dispatching to Perl build");
-            // perl_build likely expects to run from the CWD (root build_dir)
-            // It might internally use source_dir_for_build if needed, but typically runs `perl
-            // Makefile.PL` in CWD
-            perl::perl_build(source_dir_for_build, install_dir, build_env) // Pass root source dir
-        }
-        "Cargo.toml" => {
-            info!("Dispatching to Rust/Cargo");
-            // cargo_build runs `cargo build --release` from CWD (root build_dir)
-            cargo::cargo_build(install_dir, build_env)
-        }
-        "setup.py" => {
-            info!("Dispatching to Python setup.py");
-            // python_build runs `python setup.py install` from CWD (root build_dir)
-            python::python_build(install_dir, build_env)
-        }
-        "Makefile" | "makefile" => {
-            info!("Dispatching to simple Makefile");
-            // simple_make runs `make install` from CWD (root build_dir)
-            make::simple_make(install_dir, build_env)
-        }
-        // Note: Go is handled earlier as a special case.
-        _ => {
-            error!(
-                "Internal error: Unknown marker file dispatched: {}",
-                marker_filename
-            );
-            Err(SapphireError::Generic(format!(
-                "Internal error: Unknown build system marker '{}'",
-                marker_filename
-            )))
-        }
-    }
-}
-
-// --- Resource installation helpers ---
-fn install_resource(
-    resource: &ResourceSpec,
-    stage_path: &Path,   // Directory where resource was extracted
-    libexec_path: &Path, // Base libexec path (e.g., <prefix>/libexec)
-    build_env: &BuildEnvironment,
-) -> Result<()> {
-    let original_cwd = std::env::current_dir().map_err(SapphireError::Io)?;
-    debug!(
-        "Changing CWD for resource '{}' install: {}",
-        resource.name,
-        stage_path.display()
-    );
-    std::env::set_current_dir(stage_path).map_err(SapphireError::Io)?;
-    // Use RAII guard to ensure CWD restoration even on errors
-    let _cwd_guard = CurrentWorkingDirectoryGuard::new(original_cwd);
-
-    // Check for build files within the staged resource directory
-    if stage_path.join("Makefile.PL").exists() {
-        info!("   -> Detected Perl resource '{}'", resource.name);
-        install_perl_resource(resource, libexec_path, build_env)?;
-    } else if stage_path.join("setup.py").exists() {
-        info!("   -> Detected Python resource '{}'", resource.name);
-        install_python_resource(resource, libexec_path, build_env)?;
-    } else {
-        // We could potentially add more resource build system detections here (e.g., simple make
-        // install)
-        warn!(
-            "   -> Could not detect known build system (Perl/Python) for resource '{}' in {}. Skipping install.",
-            resource.name,
-            stage_path.display()
-        );
-    }
-    Ok(()) // CWD is restored when _cwd_guard goes out of scope
 }
 
 fn install_perl_resource(
@@ -869,32 +660,4 @@ fn install_single_file(source_path: &Path, formula: &Formula, install_dir: &Path
         ))
     })?;
     Ok(())
-}
-
-// --- CurrentWorkingDirectoryGuard ---
-/// Restores the original working directory when dropped (RAII).
-struct CurrentWorkingDirectoryGuard {
-    original_cwd: PathBuf,
-}
-impl CurrentWorkingDirectoryGuard {
-    fn new(original_cwd: PathBuf) -> Self {
-        Self { original_cwd }
-    }
-}
-impl Drop for CurrentWorkingDirectoryGuard {
-    fn drop(&mut self) {
-        if let Err(e) = std::env::set_current_dir(&self.original_cwd) {
-            // Use tracing::error! for consistency if tracing is the standard logger
-            error!(
-                "Failed to restore original working directory to {}: {}",
-                self.original_cwd.display(),
-                e
-            );
-        } else {
-            debug!(
-                "Restored working directory to: {}",
-                self.original_cwd.display()
-            );
-        }
-    }
 }

--- a/sapphire-core/src/build/formula/source/perl.rs
+++ b/sapphire-core/src/build/formula/source/perl.rs
@@ -6,67 +6,115 @@ use tracing::{debug, info};
 use crate::build::env::BuildEnvironment;
 use crate::utils::error::{Result, SapphireError};
 
-/// Build Perl using its Configure script
+/// Build Perl using its Configure script or Makefile.PL
 pub fn perl_build(
-    _build_dir: &Path,
+    _source_dot: &Path, // <--- Renamed and prefixed with underscore
     install_dir: &Path,
     build_env: &BuildEnvironment,
 ) -> Result<()> {
-    info!("==> Building with Perl Configure script...");
-
     let configure_script = PathBuf::from("Configure");
-    if !configure_script.exists() {
-        return Err(SapphireError::BuildEnvError(format!(
-            "Perl Configure script not found at {}",
-            configure_script.display()
-        )));
-    }
+    let makefile_pl = PathBuf::from("Makefile.PL");
 
-    let sh_exe =
-        which::which_in("sh", build_env.get_path_string(), Path::new(".")).map_err(|_| {
-            SapphireError::BuildEnvError(
-                "sh command not found in build environment PATH (needed for Perl Configure)."
-                    .to_string(),
-            )
+    // Determine which script to use
+    if configure_script.exists() {
+        info!("==> Building with Perl Configure script...");
+        let sh_exe =
+            which::which_in("sh", build_env.get_path_string(), Path::new(".")).map_err(|_| {
+                SapphireError::BuildEnvError(
+                    "sh command not found in build environment PATH (needed for Perl Configure)."
+                        .to_string(),
+                )
+            })?;
+
+        let mut cmd = Command::new(sh_exe);
+        cmd.arg(configure_script); // Runs ./Configure
+        cmd.arg("-des");
+        cmd.arg(format!("-Dprefix={}", install_dir.display()));
+
+        build_env.apply_to_command(&mut cmd);
+        info!("Running Perl Configure: {:?}", cmd);
+        let output = cmd.output().map_err(|e| {
+            SapphireError::CommandExecError(format!("Failed to execute Perl Configure: {}", e))
         })?;
 
-    let mut cmd = Command::new(sh_exe);
-    cmd.arg(configure_script);
-    cmd.arg("-des");
-    cmd.arg(format!("-Dprefix={}", install_dir.display()));
+        if !output.status.success() {
+            // (Error handling remains the same)
+            println!("Perl Configure failed with status: {}", output.status);
+            eprintln!(
+                "Perl Configure stdout:\n{}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            eprintln!(
+                "Perl Configure stderr:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return Err(SapphireError::Generic(format!(
+                "Perl Configure failed with status: {}",
+                output.status
+            )));
+        } else {
+            debug!(
+                "Perl Configure stdout:\n{}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            debug!(
+                "Perl Configure stderr:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    } else if makefile_pl.exists() {
+        info!("==> Building with Perl Makefile.PL...");
+        let perl_exe =
+            which::which_in("perl", build_env.get_path_string(), Path::new(".")).map_err(|_| {
+                SapphireError::BuildEnvError(
+                    "perl command not found in build environment PATH.".to_string(),
+                )
+            })?;
 
-    build_env.apply_to_command(&mut cmd);
-    info!("Running Perl Configure: {:?}", cmd);
-    let output = cmd.output().map_err(|e| {
-        SapphireError::CommandExecError(format!("Failed to execute Perl Configure: {}", e))
-    })?;
+        let mut cmd = Command::new(perl_exe);
+        cmd.arg("Makefile.PL"); // Runs perl Makefile.PL
+                                // Add common args if needed, e.g., INSTALL_BASE
+                                // cmd.arg(format!("INSTALL_BASE={}", install_dir.display()));
+        cmd.arg(format!("PREFIX={}", install_dir.display())); // Often uses PREFIX
 
-    if !output.status.success() {
-        println!("Perl Configure failed with status: {}", output.status);
-        eprintln!(
-            "Perl Configure stdout:\n{}",
-            String::from_utf8_lossy(&output.stdout)
-        );
-        eprintln!(
-            "Perl Configure stderr:\n{}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        return Err(SapphireError::Generic(format!(
-            "Perl Configure failed with status: {}",
-            output.status
-        )));
+        build_env.apply_to_command(&mut cmd);
+        info!("Running perl Makefile.PL: {:?}", cmd);
+        let output = cmd.output().map_err(|e| {
+            SapphireError::CommandExecError(format!("Failed to execute perl Makefile.PL: {}", e))
+        })?;
+
+        if !output.status.success() {
+            // (Error handling)
+            println!("perl Makefile.PL failed with status: {}", output.status);
+            eprintln!(
+                "perl Makefile.PL stdout:\n{}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            eprintln!(
+                "perl Makefile.PL stderr:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return Err(SapphireError::Generic(format!(
+                "perl Makefile.PL failed with status: {}",
+                output.status
+            )));
+        } else {
+            debug!(
+                "perl Makefile.PL stdout:\n{}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            debug!(
+                "perl Makefile.PL stderr:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
     } else {
-        debug!(
-            "Perl Configure stdout:\n{}",
-            String::from_utf8_lossy(&output.stdout)
-        );
-        debug!(
-            "Perl Configure stderr:\n{}",
-            String::from_utf8_lossy(&output.stderr)
-        );
+        return Err(SapphireError::BuildEnvError(
+            "Neither Perl Configure nor Makefile.PL script found in CWD.".to_string(),
+        ));
     }
 
-    // Run make
+    // Run make (common step for both Configure and Makefile.PL)
     info!("==> Running make for Perl");
     let make_exe =
         which::which_in("make", build_env.get_path_string(), Path::new(".")).map_err(|_| {
@@ -74,25 +122,26 @@ pub fn perl_build(
                 "make command not found in build environment PATH.".to_string(),
             )
         })?;
-    let mut cmd = Command::new(make_exe.clone());
-    build_env.apply_to_command(&mut cmd);
-    let output = cmd.output().map_err(|e| {
+    let mut make_cmd = Command::new(make_exe.clone());
+    build_env.apply_to_command(&mut make_cmd);
+    let output_make = make_cmd.output().map_err(|e| {
         SapphireError::CommandExecError(format!("Failed to execute make for Perl: {}", e))
     })?;
 
-    if !output.status.success() {
-        println!("Perl make failed with status: {}", output.status);
+    if !output_make.status.success() {
+        // (Error handling remains the same)
+        println!("Perl make failed with status: {}", output_make.status);
         eprintln!(
             "Perl make stdout:\n{}",
-            String::from_utf8_lossy(&output.stdout)
+            String::from_utf8_lossy(&output_make.stdout)
         );
         eprintln!(
             "Perl make stderr:\n{}",
-            String::from_utf8_lossy(&output.stderr)
+            String::from_utf8_lossy(&output_make.stderr)
         );
         return Err(SapphireError::Generic(format!(
             "Perl make failed with status: {}",
-            output.status
+            output_make.status
         )));
     } else {
         info!("Perl make completed successfully.");
@@ -100,26 +149,27 @@ pub fn perl_build(
 
     // Run make install
     info!("==> Running make install for Perl");
-    let mut cmd = Command::new(make_exe);
-    cmd.arg("install");
-    build_env.apply_to_command(&mut cmd);
-    let output = cmd.output().map_err(|e| {
+    let mut install_cmd = Command::new(make_exe);
+    install_cmd.arg("install");
+    build_env.apply_to_command(&mut install_cmd);
+    let output_install = install_cmd.output().map_err(|e| {
         SapphireError::CommandExecError(format!("Failed to execute make install for Perl: {}", e))
     })?;
 
-    if !output.status.success() {
-        println!("Perl make install failed with status: {}", output.status);
+    if !output_install.status.success() {
+        // (Error handling remains the same)
+        println!("Perl make install failed with status: {}", output_install.status);
         eprintln!(
             "Perl make install stdout:\n{}",
-            String::from_utf8_lossy(&output.stdout)
+            String::from_utf8_lossy(&output_install.stdout)
         );
         eprintln!(
             "Perl make install stderr:\n{}",
-            String::from_utf8_lossy(&output.stderr)
+            String::from_utf8_lossy(&output_install.stderr)
         );
         return Err(SapphireError::Generic(format!(
             "Perl make install failed with status: {}",
-            output.status
+            output_install.status
         )));
     } else {
         info!("Perl make install completed successfully.");

--- a/sapphire-core/src/build/formula/source/perl.rs
+++ b/sapphire-core/src/build/formula/source/perl.rs
@@ -64,8 +64,8 @@ pub fn perl_build(
         }
     } else if makefile_pl.exists() {
         info!("==> Building with Perl Makefile.PL...");
-        let perl_exe =
-            which::which_in("perl", build_env.get_path_string(), Path::new(".")).map_err(|_| {
+        let perl_exe = which::which_in("perl", build_env.get_path_string(), Path::new("."))
+            .map_err(|_| {
                 SapphireError::BuildEnvError(
                     "perl command not found in build environment PATH.".to_string(),
                 )
@@ -158,7 +158,10 @@ pub fn perl_build(
 
     if !output_install.status.success() {
         // (Error handling remains the same)
-        println!("Perl make install failed with status: {}", output_install.status);
+        println!(
+            "Perl make install failed with status: {}",
+            output_install.status
+        );
         eprintln!(
             "Perl make install stdout:\n{}",
             String::from_utf8_lossy(&output_install.stdout)


### PR DESCRIPTION
## refactor(build/source): implement CWD build detection with nesting support

This refactors the formula source build process (`build_from_source`) to improve robustness and determinism in build system detection.

### Motivation (Why)

The previous build system detection relied on a heuristic approach using `WalkDir` to search multiple directory levels and a complex scoring system to guess the most likely source root based on marker files (`configure`, `CMakeLists.txt`, etc.). This approach was fragile and could fail with non-standard project layouts or archives containing unexpected nested structures. It was difficult to predict and debug.

The goal of this refactor is to make build system detection more reliable by directly linking it to the structure of the source archive itself.

### Implementation (What)

1.  **Archive Root Inference:** Introduced `infer_archive_root_dir` to analyze the archive structure *before* extraction.
2.  **Intelligent Extraction:** Uses the inference result to set `strip_components` (1 if a single root dir is detected, 0 otherwise) during extraction via `extract_archive`. This aims to place the actual source files directly into the build directory's top level whenever possible.
3.  **CWD-Based Build:** The `build_from_source` function now changes the Current Working Directory (CWD) into the temporary build directory where files were extracted. It uses an RAII guard (`CurrentWorkingDirectoryGuard`) to ensure the CWD is restored reliably.
4.  **Simplified Detection (`detect_and_build_in_cwd`):** Replaced the old heuristic `detect_and_build` function with `detect_and_build_in_cwd`. This new function:
    * First, checks for build markers (`configure`, `CMakeLists.txt`, etc.) directly in the CWD. This handles the common case where `strip_components=1` was used.
    * If no markers are found directly in the CWD, it performs a *targeted fallback*: it checks if there is exactly *one* subdirectory (handling the `strip_components=0` case where the archive root was preserved).
    * If a single subdirectory exists, it checks for markers *inside* that subdirectory.
5.  **Build Execution Context:** Uses a helper (`with_cwd`) to ensure build functions (like `make::configure_and_make`, `cmake::cmake_build`, etc.) are executed with the CWD correctly set to the directory containing the detected build markers (either the root build dir or the single subdirectory).
6.  **Build Module Adjustments:** Updated specific build functions (`cmake::cmake_build`, `meson::meson_build`, `perl::perl_build`, `go::go_build`) to correctly handle being called from the source root CWD, passing relative paths like `.` or `..` where necessary.

### Benefits & Robustness vs. Heuristics

* **Deterministic:** Build detection is no longer a guess based on filesystem searching and scoring. It's directly tied to the structure of the source archive (via `infer_archive_root_dir`) and the resulting extraction layout (handled by the CWD + single subdir check).
* **More Robust:** Explicitly handles the two main outcomes of the extraction process (`strip_components=1` resulting in files in CWD, `strip_components=0` resulting in files in a single subdirectory). This is much less likely to break on unusual directory names or structures compared to the old `WalkDir` approach.
* **Simpler Core Logic:** The primary detection path (checking CWD) is significantly simpler. The fallback only triggers for a specific, known case.
* **Cleaner Build Function State:** Build functions (`cmake_build`, `make_build`, etc.) are now consistently called with the CWD set to the root of the source code they need to operate on, simplifying their internal logic.

This new approach provides a more predictable and maintainable foundation for building formulas from source.