### PR TITLE
Build and publish a temporary release binary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,8 +54,14 @@ jobs:
       - name: Run linters
         run: cargo clippy -- -D warnings
 
-      - name: Build
-        run: cargo build --verbose
+      - name: Build release binary
+        run: cargo build --release --verbose
 
       - name: Run tests
         run: cargo test --verbose
+
+      - name: Upload compiled binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: sapphire-macos-arm64
+          path: target/release/sapphire


### PR DESCRIPTION
This change allows users to download the latest binary.